### PR TITLE
Rename functions to use fewer underscores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This file contains the changes to the crate since version 0.1.1.
 
+## 0.5.0
+
+### Breaking changes
+
+- Remove last underscore in function names. E.g. `lambert_w_0` is renamed to `lambert_w0`.
+ This makes them easier to type and the new names are similar to the names given
+ to these functions in libraries in other languages.
+
 ## 0.4.4
 
 - Documentation improvements.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,7 +260,7 @@ dependencies = [
 
 [[package]]
 name = "lambert_w"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "approx",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambert_w"
-version = "0.4.4"
+version = "0.5.0"
 edition = "2021"
 authors = ["Johanna Sörngård <jsorngard@gmail.com>"]
 categories = ["mathematics"]

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Compute the value of the
 principal branch of the Lambert W function to 50 bits of accuracy:
 
 ```rust
-use lambert_w::lambert_w_0;
+use lambert_w::lambert_w0;
 
-let Ω = lambert_w_0(1.0);
+let Ω = lambert_w0(1.0);
 
 assert_abs_diff_eq!(Ω, 0.5671432904097838);
 ```
@@ -37,9 +37,9 @@ assert_abs_diff_eq!(Ω, 0.5671432904097838);
 or to only 24 bits of accuracy, but with faster execution time:
 
 ```rust
-use lambert_w::sp_lambert_w_0;
+use lambert_w::sp_lambert_w0;
 
-let Ω = sp_lambert_w_0(1.0);
+let Ω = sp_lambert_w0(1.0);
 
 assert_abs_diff_eq!(Ω, 0.5671432904097838, epsilon = 1e-7);
 ```
@@ -48,12 +48,12 @@ Evaluate the secondary branch of the Lambert W function at -ln(2)/2
 to 50 and 24 bits of accuracy:
 
 ```rust
-use lambert_w::{lambert_w_m1, sp_lambert_w_m1};
+use lambert_w::{lambert_wm1, sp_lambert_wm1};
 
 let z = -f64::ln(2.0) / 2.0;
 
-let mln4_50b = lambert_w_m1(z);
-let mln4_24b = sp_lambert_w_m1(z);
+let mln4_50b = lambert_wm1(z);
+let mln4_24b = sp_lambert_wm1(z);
 
 
 assert_abs_diff_eq!(mln4_50b, -f64::ln(4.0));

--- a/benches/fixed.rs
+++ b/benches/fixed.rs
@@ -1,6 +1,6 @@
 use core::hint::black_box;
 use criterion::{criterion_group, criterion_main, Criterion};
-use lambert_w::{lambert_w_0, lambert_w_m1, sp_lambert_w_0, sp_lambert_w_m1};
+use lambert_w::{lambert_w0, lambert_wm1, sp_lambert_w0, sp_lambert_wm1};
 
 fn fixed_benches(c: &mut Criterion) {
     let big_args = [
@@ -26,17 +26,15 @@ fn fixed_benches(c: &mut Criterion) {
 
     for z in big_args {
         let mut group = c.benchmark_group(format!("W_0({z})"));
-        group.bench_function(&format!("50 bits"), |b| {
-            b.iter(|| black_box(lambert_w_0(z)))
-        });
+        group.bench_function(&format!("50 bits"), |b| b.iter(|| black_box(lambert_w0(z))));
         group.bench_function(&format!("24 bits"), |b| {
-            b.iter(|| black_box(sp_lambert_w_0(z)))
+            b.iter(|| black_box(sp_lambert_w0(z)))
         });
     }
     for z in small_args {
         let mut group = c.benchmark_group(format!("W_-1({z})"));
-        group.bench_function("50 bits", |b| b.iter(|| black_box(lambert_w_m1(z))));
-        group.bench_function("24 bits", |b| b.iter(|| black_box(sp_lambert_w_m1(z))));
+        group.bench_function("50 bits", |b| b.iter(|| black_box(lambert_wm1(z))));
+        group.bench_function("24 bits", |b| b.iter(|| black_box(sp_lambert_wm1(z))));
     }
 }
 

--- a/benches/random.rs
+++ b/benches/random.rs
@@ -1,7 +1,7 @@
 use core::f64::consts::E;
 use core::hint::black_box;
 use criterion::{criterion_group, criterion_main, Criterion};
-use lambert_w::{lambert_w_0, lambert_w_m1, sp_lambert_w_0, sp_lambert_w_m1};
+use lambert_w::{lambert_w0, lambert_wm1, sp_lambert_w0, sp_lambert_wm1};
 use rand::{Rng, SeedableRng};
 use rand_pcg::Pcg32;
 use std::time::Instant;
@@ -16,7 +16,7 @@ fn random_benches(c: &mut Criterion) {
                 .collect();
             let start = Instant::now();
             for &z in &datas {
-                black_box(lambert_w_0(z));
+                black_box(lambert_w0(z));
             }
             start.elapsed()
         })
@@ -28,7 +28,7 @@ fn random_benches(c: &mut Criterion) {
                 .collect();
             let start = Instant::now();
             for &z in &datas {
-                black_box(sp_lambert_w_0(z));
+                black_box(sp_lambert_w0(z));
             }
             start.elapsed()
         })
@@ -38,7 +38,7 @@ fn random_benches(c: &mut Criterion) {
             let datas: Vec<f64> = (0..iters).map(|_| rng.gen_range(-1.0 / E..=0.0)).collect();
             let start = Instant::now();
             for &z in &datas {
-                black_box(lambert_w_m1(z));
+                black_box(lambert_wm1(z));
             }
             start.elapsed()
         })
@@ -48,7 +48,7 @@ fn random_benches(c: &mut Criterion) {
             let datas: Vec<f64> = (0..iters).map(|_| rng.gen_range(-1.0 / E..=0.0)).collect();
             let start = Instant::now();
             for &z in &datas {
-                black_box(sp_lambert_w_m1(z));
+                black_box(sp_lambert_wm1(z));
             }
             start.elapsed()
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,9 +17,9 @@
     doc = r##"
 ```
 # use approx::assert_abs_diff_eq;
-use lambert_w::lambert_w_0;
+use lambert_w::lambert_w0;
 
-let Ω = lambert_w_0(1.0);
+let Ω = lambert_w0(1.0);
 
 assert_abs_diff_eq!(Ω, 0.5671432904097838);
 ```
@@ -32,9 +32,9 @@ assert_abs_diff_eq!(Ω, 0.5671432904097838);
     doc = r##"
 ```
 # use approx::assert_abs_diff_eq;
-use lambert_w::sp_lambert_w_0;
+use lambert_w::sp_lambert_w0;
 
-let Ω = sp_lambert_w_0(1.0);
+let Ω = sp_lambert_w0(1.0);
 
 assert_abs_diff_eq!(Ω, 0.5671432904097838, epsilon = 1e-7);
 ```
@@ -46,12 +46,12 @@ assert_abs_diff_eq!(Ω, 0.5671432904097838, epsilon = 1e-7);
     doc = r##"
 ```
 # use approx::assert_abs_diff_eq;
-use lambert_w::{lambert_w_m1, sp_lambert_w_m1};
+use lambert_w::{lambert_wm1, sp_lambert_wm1};
 
 let z = -f64::ln(2.0) / 2.0;
 
-let mln4_50b = lambert_w_m1(z);
-let mln4_24b = sp_lambert_w_m1(z);
+let mln4_50b = lambert_wm1(z);
+let mln4_24b = sp_lambert_wm1(z);
 
 assert_abs_diff_eq!(mln4_50b, -f64::ln(4.0));
 assert_abs_diff_eq!(mln4_24b, -f64::ln(4.0), epsilon = 1e-9);
@@ -109,18 +109,18 @@ pub const OMEGA: f64 = 0.567_143_290_409_783_8;
 /// Basic usage:
 /// ```
 /// # use approx::assert_abs_diff_eq;
-/// use lambert_w::sp_lambert_w_0;
+/// use lambert_w::sp_lambert_w0;
 ///
-/// let Ω = sp_lambert_w_0(1.0);
+/// let Ω = sp_lambert_w0(1.0);
 ///
 /// assert_abs_diff_eq!(Ω, 0.5671432904097838, epsilon = 1e-7);
 /// ```
 /// Arguments smaller than -1/e (≈ -0.36787944117144233) result in [`NAN`](f64::NAN):
 /// ```
-/// # use lambert_w::sp_lambert_w_0;
-/// assert!(sp_lambert_w_0(-1.0).is_nan());
+/// # use lambert_w::sp_lambert_w0;
+/// assert!(sp_lambert_w0(-1.0).is_nan());
 /// ```
-pub fn sp_lambert_w_0(z: f64) -> f64 {
+pub fn sp_lambert_w0(z: f64) -> f64 {
     sw0::sw0(z)
 }
 
@@ -134,19 +134,19 @@ pub fn sp_lambert_w_0(z: f64) -> f64 {
 /// Basic usage:
 /// ```
 /// # use approx::assert_abs_diff_eq;
-/// use lambert_w::sp_lambert_w_m1;
+/// use lambert_w::sp_lambert_wm1;
 ///
-/// let mln4 = sp_lambert_w_m1(-f64::ln(2.0) / 2.0);
+/// let mln4 = sp_lambert_wm1(-f64::ln(2.0) / 2.0);
 ///
 /// assert_abs_diff_eq!(mln4, -f64::ln(4.0), epsilon = 1e-9);
 /// ```
 /// Arguments smaller than -1/e (≈ -0.36787944117144233) or larger than 0 result in [`NAN`](f64::NAN):
 /// ```
-/// # use lambert_w::sp_lambert_w_m1;
-/// assert!(sp_lambert_w_m1(-1.0).is_nan());
-/// assert!(sp_lambert_w_m1(1.0).is_nan());
+/// # use lambert_w::sp_lambert_wm1;
+/// assert!(sp_lambert_wm1(-1.0).is_nan());
+/// assert!(sp_lambert_wm1(1.0).is_nan());
 /// ```
-pub fn sp_lambert_w_m1(z: f64) -> f64 {
+pub fn sp_lambert_wm1(z: f64) -> f64 {
     swm1::swm1(z)
 }
 
@@ -160,18 +160,18 @@ pub fn sp_lambert_w_m1(z: f64) -> f64 {
 /// Basic usage:
 /// ```
 /// # use approx::assert_abs_diff_eq;
-/// use lambert_w::lambert_w_0;
+/// use lambert_w::lambert_w0;
 ///
-/// let Ω = lambert_w_0(1.0);
+/// let Ω = lambert_w0(1.0);
 ///
 /// assert_abs_diff_eq!(Ω, 0.5671432904097838);
 /// ```
 /// Arguments smaller than -1/e (≈ -0.36787944117144233) result in [`NAN`](f64::NAN):
 /// ```
-/// # use lambert_w::lambert_w_0;
-/// assert!(lambert_w_0(-1.0).is_nan());
+/// # use lambert_w::lambert_w0;
+/// assert!(lambert_w0(-1.0).is_nan());
 /// ```
-pub fn lambert_w_0(z: f64) -> f64 {
+pub fn lambert_w0(z: f64) -> f64 {
     dw0c::dw0c(z - NEG_INV_E)
 }
 
@@ -185,19 +185,19 @@ pub fn lambert_w_0(z: f64) -> f64 {
 /// Basic usage:
 /// ```
 /// # use approx::assert_abs_diff_eq;
-/// use lambert_w::lambert_w_m1;
+/// use lambert_w::lambert_wm1;
 ///
-/// let mln4 = lambert_w_m1(-f64::ln(2.0) / 2.0);
+/// let mln4 = lambert_wm1(-f64::ln(2.0) / 2.0);
 ///
 /// assert_abs_diff_eq!(mln4, -f64::ln(4.0), epsilon = 1e-14);
 /// ```
 /// Arguments smaller than -1/e (≈ -0.36787944117144233) or larger than 0 result in [`NAN`](f64::NAN):
 /// ```
-/// # use lambert_w::lambert_w_m1;
-/// assert!(lambert_w_m1(-1.0).is_nan());
-/// assert!(lambert_w_m1(1.0).is_nan());
+/// # use lambert_w::lambert_wm1;
+/// assert!(lambert_wm1(-1.0).is_nan());
+/// assert!(lambert_wm1(1.0).is_nan());
 /// ```
-pub fn lambert_w_m1(z: f64) -> f64 {
+pub fn lambert_wm1(z: f64) -> f64 {
     dwm1c::dwm1c(z, z - NEG_INV_E)
 }
 
@@ -207,443 +207,440 @@ mod test {
     // This is because CI may not have fused multiply-add instructions, which creates numerical instabillity.
 
     #[cfg(feature = "50bits")]
-    use super::{lambert_w_0, lambert_w_m1};
+    use super::{lambert_w0, lambert_wm1};
     #[cfg(feature = "24bits")]
-    use super::{sp_lambert_w_0, sp_lambert_w_m1};
+    use super::{sp_lambert_w0, sp_lambert_wm1};
     use approx::assert_abs_diff_eq;
     use core::f64::consts::E;
 
     #[cfg(feature = "50bits")]
     #[test]
-    fn test_lambert_w_0() {
-        assert!(lambert_w_0(-1.0 / E - f64::EPSILON).is_nan());
-        assert_abs_diff_eq!(lambert_w_0(-2.678794411714424e-01), -3.993824525397807e-01);
-        assert_abs_diff_eq!(lambert_w_0(6.321205588285577e-01), 4.167039988177658e-01);
+    fn test_lambert_w0() {
+        assert!(lambert_w0(-1.0 / E - f64::EPSILON).is_nan());
+        assert_abs_diff_eq!(lambert_w0(-2.678794411714424e-01), -3.993824525397807e-01);
+        assert_abs_diff_eq!(lambert_w0(6.321205588285577e-01), 4.167039988177658e-01);
         #[cfg(not(feature = "estrin"))]
-        assert_abs_diff_eq!(lambert_w_0(9.632120558828557), 1.721757710976171);
+        assert_abs_diff_eq!(lambert_w0(9.632120558828557), 1.721757710976171);
         #[cfg(feature = "estrin")]
         assert_abs_diff_eq!(
-            lambert_w_0(9.632120558828557),
+            lambert_w0(9.632120558828557),
             1.721757710976171,
             epsilon = 1e-14
         );
-        assert_abs_diff_eq!(lambert_w_0(9.963212055882856e+01), 3.382785211058958);
-        assert_abs_diff_eq!(lambert_w_0(9.996321205588285e+02), 5.249293782013269);
+        assert_abs_diff_eq!(lambert_w0(9.963212055882856e+01), 3.382785211058958);
+        assert_abs_diff_eq!(lambert_w0(9.996321205588285e+02), 5.249293782013269);
         assert_abs_diff_eq!(
-            lambert_w_0(9.999632120558828e+03),
+            lambert_w0(9.999632120558828e+03),
             7.231813718542178,
             epsilon = 1e-14
         );
         #[cfg(not(feature = "estrin"))]
-        assert_abs_diff_eq!(lambert_w_0(9.999963212055883e+04), 9.284568107521959);
+        assert_abs_diff_eq!(lambert_w0(9.999963212055883e+04), 9.284568107521959);
         #[cfg(feature = "estrin")]
         assert_abs_diff_eq!(
-            lambert_w_0(9.999963212055883e+04),
+            lambert_w0(9.999963212055883e+04),
             9.284568107521959,
             epsilon = 1e-14
         );
         #[cfg(not(feature = "estrin"))]
-        assert_abs_diff_eq!(lambert_w_0(9.999996321205589e+05), 1.138335774796812e+01);
+        assert_abs_diff_eq!(lambert_w0(9.999996321205589e+05), 1.138335774796812e+01);
         #[cfg(feature = "estrin")]
         assert_abs_diff_eq!(
-            lambert_w_0(9.999996321205589e+05),
+            lambert_w0(9.999996321205589e+05),
             1.138335774796812e+01,
             epsilon = 1e-14
         );
         #[cfg(not(feature = "estrin"))]
-        assert_abs_diff_eq!(lambert_w_0(9.999999632120559e+06), 1.351434397605273e+01);
+        assert_abs_diff_eq!(lambert_w0(9.999999632120559e+06), 1.351434397605273e+01);
         #[cfg(feature = "estrin")]
         assert_abs_diff_eq!(
-            lambert_w_0(9.999999632120559e+06),
+            lambert_w0(9.999999632120559e+06),
             1.351434397605273e+01,
             epsilon = 1e-14
         );
         assert_abs_diff_eq!(
-            lambert_w_0(9.999999963212056e+07),
+            lambert_w0(9.999999963212056e+07),
             1.566899671199287e+01,
             epsilon = 1e-14
         );
         assert_abs_diff_eq!(
-            lambert_w_0(9.999999996321206e+08),
+            lambert_w0(9.999999996321206e+08),
             1.784172596707312e+01,
             epsilon = 1e-14
         );
         assert_abs_diff_eq!(
-            lambert_w_0(9.999999999632120e+09),
+            lambert_w0(9.999999999632120e+09),
             2.002868541326992e+01,
             epsilon = 1e-14
         );
         #[cfg(not(feature = "estrin"))]
-        assert_abs_diff_eq!(lambert_w_0(9.999999999963213e+10), 2.222712273495755e+01);
+        assert_abs_diff_eq!(lambert_w0(9.999999999963213e+10), 2.222712273495755e+01);
         #[cfg(feature = "estrin")]
         assert_abs_diff_eq!(
-            lambert_w_0(9.999999999963213e+10),
+            lambert_w0(9.999999999963213e+10),
             2.222712273495755e+01,
             epsilon = 1e-14
         );
         assert_abs_diff_eq!(
-            lambert_w_0(9.999999999996321e+11),
+            lambert_w0(9.999999999996321e+11),
             2.443500440493456e+01,
             epsilon = 1e-14
         );
         #[cfg(not(feature = "estrin"))]
         assert_abs_diff_eq!(
-            lambert_w_0(9.999999999999633e+12),
+            lambert_w0(9.999999999999633e+12),
             2.665078750870219e+01,
             epsilon = 1e-14
         );
         #[cfg(feature = "estrin")]
         assert_abs_diff_eq!(
-            lambert_w_0(9.999999999999633e+12),
+            lambert_w0(9.999999999999633e+12),
             2.665078750870219e+01,
             epsilon = 1e-13
         );
         assert_abs_diff_eq!(
-            lambert_w_0(9.999999999999962e+13),
+            lambert_w0(9.999999999999962e+13),
             2.887327487929930e+01,
             epsilon = 1e-14
         );
         assert_abs_diff_eq!(
-            lambert_w_0(9.999999999999996e+14),
+            lambert_w0(9.999999999999996e+14),
             3.110151971159478e+01,
             epsilon = 1e-14
         );
         assert_abs_diff_eq!(
-            lambert_w_0(1.000000000000000e+16),
+            lambert_w0(1.000000000000000e+16),
             3.333476076844818e+01,
             epsilon = 1e-14
         );
         #[cfg(not(feature = "estrin"))]
-        assert_abs_diff_eq!(lambert_w_0(1.000000000000000e+17), 3.557237716651325e+01);
+        assert_abs_diff_eq!(lambert_w0(1.000000000000000e+17), 3.557237716651325e+01);
         #[cfg(feature = "estrin")]
         assert_abs_diff_eq!(
-            lambert_w_0(1.000000000000000e+17),
+            lambert_w0(1.000000000000000e+17),
             3.557237716651325e+01,
             epsilon = 1e-14
         );
         assert_abs_diff_eq!(
-            lambert_w_0(1.000000000000000e+18),
+            lambert_w0(1.000000000000000e+18),
             3.781385607558877e+01,
             epsilon = 1e-14
         );
         assert_abs_diff_eq!(
-            lambert_w_0(1.000000000000000e+19),
+            lambert_w0(1.000000000000000e+19),
             4.005876916198432e+01,
             epsilon = 1e-14
         );
         #[cfg(not(feature = "estrin"))]
-        assert_abs_diff_eq!(lambert_w_0(1.000000000000000e+20), 4.230675509173839e+01);
+        assert_abs_diff_eq!(lambert_w0(1.000000000000000e+20), 4.230675509173839e+01);
         #[cfg(feature = "estrin")]
         assert_abs_diff_eq!(
-            lambert_w_0(1.000000000000000e+20),
+            lambert_w0(1.000000000000000e+20),
             4.230675509173839e+01,
             epsilon = 1e-14
         );
         #[cfg(not(feature = "estrin"))]
-        assert_abs_diff_eq!(lambert_w_0(1.000000000000000e+40), 8.763027715194720e+01);
+        assert_abs_diff_eq!(lambert_w0(1.000000000000000e+40), 8.763027715194720e+01);
         #[cfg(feature = "estrin")]
         assert_abs_diff_eq!(
-            lambert_w_0(1.000000000000000e+40),
+            lambert_w0(1.000000000000000e+40),
             8.763027715194720e+01,
             epsilon = 1e-13
         );
         assert_abs_diff_eq!(
-            lambert_w_0(1.000000000000000e+80),
+            lambert_w0(1.000000000000000e+80),
             1.790193137415062e+02,
             epsilon = 1e-13
         );
         assert_abs_diff_eq!(
-            lambert_w_0(1.000000000000000e+120),
+            lambert_w0(1.000000000000000e+120),
             2.707091661024979e+02,
             epsilon = 1e-13
         );
-        assert_abs_diff_eq!(lambert_w_0(1.000000000000000e+160), 3.625205337614976e+02);
-        assert_abs_diff_eq!(lambert_w_0(f64::MAX), 703.2270331047702, epsilon = 1e-12);
+        assert_abs_diff_eq!(lambert_w0(1.000000000000000e+160), 3.625205337614976e+02);
+        assert_abs_diff_eq!(lambert_w0(f64::MAX), 703.2270331047702, epsilon = 1e-12);
     }
 
     #[cfg(feature = "24bits")]
     #[test]
-    fn test_sp_lambert_w_0() {
-        assert!(sp_lambert_w_0(-1.0 / E - f64::EPSILON).is_nan());
+    fn test_sp_lambert_w0() {
+        assert!(sp_lambert_w0(-1.0 / E - f64::EPSILON).is_nan());
         assert_abs_diff_eq!(
-            sp_lambert_w_0(-2.678794411714424e-01),
+            sp_lambert_w0(-2.678794411714424e-01),
             -3.993824525397807e-01,
             epsilon = 1e-7
         );
         assert_abs_diff_eq!(
-            sp_lambert_w_0(6.321205588285577e-01),
+            sp_lambert_w0(6.321205588285577e-01),
             4.167039988177658e-01,
             epsilon = 1e-7
         );
         assert_abs_diff_eq!(
-            sp_lambert_w_0(9.632120558828557),
+            sp_lambert_w0(9.632120558828557),
             1.721757710976171,
             epsilon = 1e-7
         );
         assert_abs_diff_eq!(
-            sp_lambert_w_0(9.963212055882856e+01),
+            sp_lambert_w0(9.963212055882856e+01),
             3.382785211058958,
             epsilon = 1e-7
         );
         assert_abs_diff_eq!(
-            sp_lambert_w_0(9.996321205588285e+02),
+            sp_lambert_w0(9.996321205588285e+02),
             5.249293782013269,
             epsilon = 1e-6
         );
         assert_abs_diff_eq!(
-            sp_lambert_w_0(9.999632120558828e+03),
+            sp_lambert_w0(9.999632120558828e+03),
             7.231813718542178,
             epsilon = 1e-7
         );
         assert_abs_diff_eq!(
-            sp_lambert_w_0(9.999963212055883e+04),
+            sp_lambert_w0(9.999963212055883e+04),
             9.284568107521959,
             epsilon = 1e-6
         );
         assert_abs_diff_eq!(
-            sp_lambert_w_0(9.999996321205589e+05),
+            sp_lambert_w0(9.999996321205589e+05),
             1.138335774796812e+01,
             epsilon = 1e-8
         );
         assert_abs_diff_eq!(
-            sp_lambert_w_0(9.999999632120559e+06),
+            sp_lambert_w0(9.999999632120559e+06),
             1.351434397605273e+01,
             epsilon = 1e-6
         );
         assert_abs_diff_eq!(
-            sp_lambert_w_0(9.999999963212056e+07),
+            sp_lambert_w0(9.999999963212056e+07),
             1.566899671199287e+01,
             epsilon = 1e-6
         );
         assert_abs_diff_eq!(
-            sp_lambert_w_0(9.999999996321206e+08),
+            sp_lambert_w0(9.999999996321206e+08),
             1.784172596707312e+01,
             epsilon = 1e-6
         );
         assert_abs_diff_eq!(
-            sp_lambert_w_0(9.999999999632120e+09),
+            sp_lambert_w0(9.999999999632120e+09),
             2.002868541326992e+01,
             epsilon = 1e-6
         );
         assert_abs_diff_eq!(
-            sp_lambert_w_0(9.999999999963213e+10),
+            sp_lambert_w0(9.999999999963213e+10),
             2.222712273495755e+01,
             epsilon = 1e-6
         );
         assert_abs_diff_eq!(
-            sp_lambert_w_0(9.999999999996321e+11),
+            sp_lambert_w0(9.999999999996321e+11),
             2.443500440493456e+01,
             epsilon = 1e-5
         );
         assert_abs_diff_eq!(
-            sp_lambert_w_0(9.999999999999633e+12),
+            sp_lambert_w0(9.999999999999633e+12),
             2.665078750870219e+01,
             epsilon = 1e-6
         );
         assert_abs_diff_eq!(
-            sp_lambert_w_0(9.999999999999962e+13),
+            sp_lambert_w0(9.999999999999962e+13),
             2.887327487929930e+01,
             epsilon = 1e-6
         );
         assert_abs_diff_eq!(
-            sp_lambert_w_0(9.999999999999996e+14),
+            sp_lambert_w0(9.999999999999996e+14),
             3.110151971159478e+01,
             epsilon = 1e-5
         );
         assert_abs_diff_eq!(
-            sp_lambert_w_0(1.000000000000000e+16),
+            sp_lambert_w0(1.000000000000000e+16),
             3.333476076844818e+01,
             epsilon = 1e-6
         );
         assert_abs_diff_eq!(
-            sp_lambert_w_0(1.000000000000000e+17),
+            sp_lambert_w0(1.000000000000000e+17),
             3.557237716651325e+01,
             epsilon = 1e-5
         );
         assert_abs_diff_eq!(
-            sp_lambert_w_0(1.000000000000000e+18),
+            sp_lambert_w0(1.000000000000000e+18),
             3.781385607558877e+01,
             epsilon = 1e-5
         );
         assert_abs_diff_eq!(
-            sp_lambert_w_0(1.000000000000000e+19),
+            sp_lambert_w0(1.000000000000000e+19),
             4.005876916198432e+01,
             epsilon = 1e-6
         );
         assert_abs_diff_eq!(
-            sp_lambert_w_0(1.000000000000000e+20),
+            sp_lambert_w0(1.000000000000000e+20),
             4.230675509173839e+01,
             epsilon = 1e-5
         );
         assert_abs_diff_eq!(
-            sp_lambert_w_0(1.000000000000000e+40),
+            sp_lambert_w0(1.000000000000000e+40),
             8.763027715194720e+01,
             epsilon = 1e-5
         );
         assert_abs_diff_eq!(
-            sp_lambert_w_0(1.000000000000000e+80),
+            sp_lambert_w0(1.000000000000000e+80),
             1.790193137415062e+02,
             epsilon = 1e-5
         );
         assert_abs_diff_eq!(
-            sp_lambert_w_0(1.000000000000000e+120),
+            sp_lambert_w0(1.000000000000000e+120),
             2.707091661024979e+02,
             epsilon = 1e-4
         );
         assert_abs_diff_eq!(
-            sp_lambert_w_0(1.000000000000000e+160),
+            sp_lambert_w0(1.000000000000000e+160),
             3.625205337614976e+02,
             epsilon = 1e-4
         );
-        assert_abs_diff_eq!(sp_lambert_w_0(f64::MAX), 703.2270331047702, epsilon = 1e-4);
+        assert_abs_diff_eq!(sp_lambert_w0(f64::MAX), 703.2270331047702, epsilon = 1e-4);
     }
 
     #[cfg(feature = "50bits")]
     #[test]
-    fn test_lambert_w_m1() {
-        assert!(lambert_w_m1(-1.0 / E - f64::EPSILON).is_nan());
+    fn test_lambert_wm1() {
+        assert!(lambert_wm1(-1.0 / E - f64::EPSILON).is_nan());
         assert_abs_diff_eq!(
-            lambert_w_m1(-3.578794411714423e-01),
+            lambert_wm1(-3.578794411714423e-01),
             -1.253493791367214,
             epsilon = 1e-14
         );
         assert_abs_diff_eq!(
-            lambert_w_m1(-2.678794411714424e-01),
+            lambert_wm1(-2.678794411714424e-01),
             -2.020625228775403,
             epsilon = 1e-14
         );
-        assert_abs_diff_eq!(lambert_w_m1(-1.000000000000000e-01), -3.577152063957297);
+        assert_abs_diff_eq!(lambert_wm1(-1.000000000000000e-01), -3.577152063957297);
         #[cfg(not(feature = "estrin"))]
-        assert_abs_diff_eq!(lambert_w_m1(-3.000000000000000e-02), -5.144482721515681);
+        assert_abs_diff_eq!(lambert_wm1(-3.000000000000000e-02), -5.144482721515681);
         #[cfg(feature = "estrin")]
         assert_abs_diff_eq!(
-            lambert_w_m1(-3.000000000000000e-02),
+            lambert_wm1(-3.000000000000000e-02),
             -5.144482721515681,
             epsilon = 1e-14
         );
         assert_abs_diff_eq!(
-            lambert_w_m1(-1.000000000000000e-02),
+            lambert_wm1(-1.000000000000000e-02),
             -6.472775124394005,
             epsilon = 1e-14
         );
         assert_abs_diff_eq!(
-            lambert_w_m1(-3.000000000000000e-03),
+            lambert_wm1(-3.000000000000000e-03),
             -7.872521380098709,
             epsilon = 1e-14
         );
         assert_abs_diff_eq!(
-            lambert_w_m1(-1.000000000000000e-03),
+            lambert_wm1(-1.000000000000000e-03),
             -9.118006470402742,
             epsilon = 1e-14
         );
         assert_abs_diff_eq!(
-            lambert_w_m1(-3.000000000000001e-04),
+            lambert_wm1(-3.000000000000001e-04),
             -1.045921112040100e+01,
             epsilon = 1e-14
         );
         assert_abs_diff_eq!(
-            lambert_w_m1(-1.000000000000000e-04),
+            lambert_wm1(-1.000000000000000e-04),
             -1.166711453256636e+01,
             epsilon = 1e-14
         );
         assert_abs_diff_eq!(
-            lambert_w_m1(-3.000000000000000e-05),
+            lambert_wm1(-3.000000000000000e-05),
             -1.297753279184081e+01,
             epsilon = 1e-14
         );
         assert_abs_diff_eq!(
-            lambert_w_m1(-1.000000000000000e-05),
+            lambert_wm1(-1.000000000000000e-05),
             -1.416360081581018e+01,
             epsilon = 1e-14
         );
         assert_abs_diff_eq!(
-            lambert_w_m1(-1.000000000000004e-75),
+            lambert_wm1(-1.000000000000004e-75),
             -1.778749628219512e+02,
             epsilon = 1e-13
         );
         #[cfg(not(feature = "estrin"))]
-        assert_abs_diff_eq!(
-            lambert_w_m1(-1.000000000000008e-145),
-            -3.397029099254290e+02
-        );
+        assert_abs_diff_eq!(lambert_wm1(-1.000000000000008e-145), -3.397029099254290e+02);
         #[cfg(feature = "estrin")]
         assert_abs_diff_eq!(
-            lambert_w_m1(-1.000000000000008e-145),
+            lambert_wm1(-1.000000000000008e-145),
             -3.397029099254290e+02,
             epsilon = 1e-12
         );
-        assert!(lambert_w_m1(f64::EPSILON).is_nan());
+        assert!(lambert_wm1(f64::EPSILON).is_nan());
     }
 
     #[cfg(feature = "24bits")]
     #[test]
-    fn test_sp_lambert_w_m1() {
-        assert!(sp_lambert_w_m1(-1.0 / E - f64::EPSILON).is_nan());
+    fn test_sp_lambert_wm1() {
+        assert!(sp_lambert_wm1(-1.0 / E - f64::EPSILON).is_nan());
         assert_abs_diff_eq!(
-            sp_lambert_w_m1(-3.578794411714423e-01),
+            sp_lambert_wm1(-3.578794411714423e-01),
             -1.253493791367214,
             epsilon = 1e-7
         );
         assert_abs_diff_eq!(
-            sp_lambert_w_m1(-2.678794411714424e-01),
+            sp_lambert_wm1(-2.678794411714424e-01),
             -2.020625228775403,
             epsilon = 1e-7
         );
         assert_abs_diff_eq!(
-            sp_lambert_w_m1(-1.000000000000000e-01),
+            sp_lambert_wm1(-1.000000000000000e-01),
             -3.577152063957297,
             epsilon = 1e-9
         );
         assert_abs_diff_eq!(
-            sp_lambert_w_m1(-3.000000000000000e-02),
+            sp_lambert_wm1(-3.000000000000000e-02),
             -5.144482721515681,
             epsilon = 1e-9
         );
         assert_abs_diff_eq!(
-            sp_lambert_w_m1(-1.000000000000000e-02),
+            sp_lambert_wm1(-1.000000000000000e-02),
             -6.472775124394005,
             epsilon = 1e-6
         );
         assert_abs_diff_eq!(
-            sp_lambert_w_m1(-3.000000000000000e-03),
+            sp_lambert_wm1(-3.000000000000000e-03),
             -7.872521380098709,
             epsilon = 1e-6
         );
         assert_abs_diff_eq!(
-            sp_lambert_w_m1(-1.000000000000000e-03),
+            sp_lambert_wm1(-1.000000000000000e-03),
             -9.118006470402742,
             epsilon = 1e-6
         );
         assert_abs_diff_eq!(
-            sp_lambert_w_m1(-3.000000000000001e-04),
+            sp_lambert_wm1(-3.000000000000001e-04),
             -1.045921112040100e+01,
             epsilon = 1e-6
         );
         assert_abs_diff_eq!(
-            sp_lambert_w_m1(-1.000000000000000e-04),
+            sp_lambert_wm1(-1.000000000000000e-04),
             -1.166711453256636e+01,
             epsilon = 1e-6
         );
         assert_abs_diff_eq!(
-            sp_lambert_w_m1(-3.000000000000000e-05),
+            sp_lambert_wm1(-3.000000000000000e-05),
             -1.297753279184081e+01,
             epsilon = 1e-6
         );
         assert_abs_diff_eq!(
-            sp_lambert_w_m1(-1.000000000000000e-05),
+            sp_lambert_wm1(-1.000000000000000e-05),
             -1.416360081581018e+01,
             epsilon = 1e-6
         );
         assert_abs_diff_eq!(
-            sp_lambert_w_m1(-1.000000000000004e-75),
+            sp_lambert_wm1(-1.000000000000004e-75),
             -1.778749628219512e+02,
             epsilon = 1e-5
         );
         assert_abs_diff_eq!(
-            sp_lambert_w_m1(-1.000000000000008e-145),
+            sp_lambert_wm1(-1.000000000000008e-145),
             -3.397029099254290e+02,
             epsilon = 1e-4
         );
-        assert!(sp_lambert_w_m1(f64::EPSILON).is_nan());
+        assert!(sp_lambert_wm1(f64::EPSILON).is_nan());
     }
 }


### PR DESCRIPTION
It is annoying to write so many underscores. Especially if I will add derivatives, which add another underscore. Also this makes the names more similar to other libraries in other languages.