### PR TITLE
Add code coverage job to, and remove benchmark from, CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -72,3 +72,24 @@ jobs:
     - uses: dtolnay/rust-toolchain@stable
     - name: bench
       run: cargo bench random && cargo bench random --no-default-features -F std,24bits,50bits && cargo bench random --no-default-features -F std,24bits,50bits,estrin
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - name: cargo install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: cargo generate-lockfile
+        if: hashFiles('Cargo.lock') == ''
+        run: cargo generate-lockfile
+      - name: cargo llvm-cov
+        run: cargo llvm-cov --locked --all-features --lcov --output-path lcov.info
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          fail_ci_if_error: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,7 +71,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
     - name: bench
-      run: cargo bench random && cargo bench random --no-default-features -F std,24bits,50bits && cargo bench random --no-default-features -F std,24bits,50bits,estrin
+      run: cargo bench random
 
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -65,14 +65,6 @@ jobs:
     - name: clippy_1.60
       run: cargo +1.60.0 clippy --all-features -- -D warnings
 
-  bench:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@stable
-    - name: bench
-      run: cargo bench random
-
   coverage:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Crates.io Version](https://img.shields.io/crates/v/lambert_w?logo=rust)](https://crates.io/crates/lambert_w)
 [![docs.rs](https://img.shields.io/docsrs/lambert_w?logo=docs.rs)](https://docs.rs/lambert_w/latest/lambert_w/)
 [![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/JSorngard/lambert_w/rust.yml?logo=github&label=CI)](https://github.com/JSorngard/lambert_w/actions/workflows/rust.yml)
+[![codecov](https://codecov.io/gh/JSorngard/lambert_w/graph/badge.svg?token=F61FO63ZKW)](https://codecov.io/gh/JSorngard/lambert_w)
 
 Fast and accurate evaluation of the real valued parts of the principal and
 secondary branches of the [Lambert W function](https://en.wikipedia.org/wiki/Lambert_W_function)


### PR DESCRIPTION
I don't really use the benchmark results from CI anyway. If I want to benchmark I do it on my own computer.