### PR TITLE
Make crate unconditionally `no_std`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file contains the changes to the crate since version 0.1.1.
 
+## 1.0.9
+
+- Switched the way the crate depends on the standard library such that the prelude is always the same.
+
 ## 1.0.8
 
 - Fixed a bug where the principal branch functions would return NaN when given

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This file contains the changes to the crate since version 0.1.1.
 
 ## Unreleased
 
-- Switched the way the crate depends on the standard library such that the prelude is always the same.
+- Switched the way the crate depends on the standard library such that the implicit prelude is always the same.
 
 ## 1.0.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This file contains the changes to the crate since version 0.1.1.
 
-## 1.0.9
+## Unreleased
 
 - Switched the way the crate depends on the standard library such that the prelude is always the same.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "lambert_w"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "approx",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambert_w"
-version = "1.0.8"
+version = "1.0.9"
 edition = "2021"
 authors = ["Johanna Sörngård <jsorngard@gmail.com>"]
 categories = ["mathematics", "no-std", "no-std::no-alloc"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,8 +109,11 @@
 //!
 //! [⬆️ Back to top](#description).
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 #![forbid(unsafe_code)]
+
+#[cfg(feature = "std")]
+extern crate std;
 
 #[cfg(all(not(feature = "std"), not(feature = "libm")))]
 compile_error!("at least one of the `std` or `libm` features must be enabled");


### PR DESCRIPTION
And the add std as an extern crate when the `std` feature is enabled.

This makes the implicit prelude the same regardless of whether the `std` feature is enabled or not.

Additional information: https://www.reddit.com/r/rust/comments/1hs6spy/psa_for_std_feature_in_no_std_libraries/