### PR TITLE
Try using `ubuntu-latest` in CI again

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,6 +50,7 @@ jobs:
     - uses: taiki-e/install-action@v2
       with:
         tool: cargo-all-features
+    - run: sudo apt-get -y install libfontconfig1-dev jq
     - name: Test
       run: cargo test-all-features
       

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,7 +43,7 @@ jobs:
       run: cargo clippy --all-features -- -D warnings
       
   test:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
@@ -76,7 +76,7 @@ jobs:
       run: cargo msrv --output-format minimal verify
 
   run_examples:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
@@ -84,7 +84,7 @@ jobs:
       run: cargo run --example plot
 
   coverage:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -81,6 +81,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
+    - run: sudo apt-get -y install libfontconfig1-dev jq
     - name: Run examples
       run: cargo run --example plot
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -91,6 +91,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
+      - run: sudo apt-get -y install libfontconfig1-dev jq
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate lockfile


### PR DESCRIPTION
The affected jobs used to fail on `ubuntu-latest` and were moved to `windows-latest`. That is much slower and not as compatible with `codecov`, so this PR changes them back to `ubuntu-latest`.

Related issue: https://github.com/yeslogic/fontconfig-rs/issues/42.