### PR TITLE
Remove note about the accuracy of the functions on the trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 This file contains the changes to the crate since version 0.1.1.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.13
+
+- Removed the note about the accuracy on the trait functions,
+ as that is different depending on the type that the trait is invoked on.
+
 ## 1.0.12
 
 - Noted the accuracy of the functions on the trait in the example. 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "lambert_w"
-version = "1.0.12"
+version = "1.0.13"
 dependencies = [
  "approx",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambert_w"
-version = "1.0.12"
+version = "1.0.13"
 edition = "2021"
 authors = ["Johanna Sörngård <jsorngard@gmail.com>"]
 categories = ["mathematics", "no-std", "no-std::no-alloc"]

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ assert_relative_eq!(big, 703.2270331047702, max_relative = 4e-16);
 assert_relative_eq!(tiny, -715.7695669234213, max_relative = 4e-16);
 ```
 
-Importing the `LambertW` trait lets you call the functions with 50 bits of accuracy with postfix notation:
+Importing the `LambertW` trait lets you call the functions with postfix notation:
 
 ```rust
 use lambert_w::LambertW;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@
 //! assert_relative_eq!(tiny, -715.7695669234213, max_relative = 4e-16);
 //! ```
 //!
-//! Importing the [`LambertW`] trait lets you call the functions with 50 bits of accuracy with postfix notation:
+//! Importing the [`LambertW`] trait lets you call the functions with postfix notation:
 //!
 //! ```
 //! # use approx::assert_abs_diff_eq;


### PR DESCRIPTION
This is because the accuracy is of course different depending on what the type is.