### PR TITLE
Attempt to speed up MSRV verification

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,12 +70,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@stable
+    - uses: dtolnay/rust-toolchain@1.63.0
     - uses: taiki-e/install-action@v2
-      with:
-        tool: cargo-msrv
     - name: Verify MSRV
-      run: cargo msrv --output-format minimal verify
+      run: cargo check
 
   run_examples:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Instead of installing the latest Rust version and running `cargo-msrv`, we install the MSRV and just run `cargo check`.