### PR TITLE
Add CI job to test on Rust beta

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -127,3 +127,16 @@ jobs:
     - name: Compile benchmarks, but do not run them
       # There are no benchmarks with "nothing" in their name, hence this command only compiles the benchmarks but does not run them.
       run: cargo bench nothing
+
+  beta_test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@beta
+    - name: Install libfontconfig1-dev
+      run: sudo apt-get -y install libfontconfig1-dev jq
+    - uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-all-features 
+    - name: Test the crate on rust beta
+      run: cargo test-all-features


### PR DESCRIPTION
Discover potential future breakage earlier. 
Might help with reporting bugs to the Rust project.