### PR TITLE
Attempt to speed up semver checks CI job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -114,8 +114,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Check semver
-        uses: obi1kenobi/cargo-semver-checks-action@v2
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-semver-checks
+      - name: Verify semver compatibility
+        run: cargo semver-checks
 
   bench:
     runs-on: ubuntu-latest

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,7 +175,6 @@ pub const OMEGA: f64 = 0.567_143_290_409_783_8;
 /// # Reference
 ///
 /// [Toshio Fukushima, Precise and fast computation of Lambert W function by piecewise minimax rational function approximation with variable transformation](https://www.researchgate.net/publication/346309410_Precise_and_fast_computation_of_Lambert_W_function_by_piecewise_minimax_rational_function_approximation_with_variable_transformation).
-#[must_use]
 pub fn sp_lambert_w0(z: f64) -> f64 {
     sw0::sw0(z)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,6 +175,7 @@ pub const OMEGA: f64 = 0.567_143_290_409_783_8;
 /// # Reference
 ///
 /// [Toshio Fukushima, Precise and fast computation of Lambert W function by piecewise minimax rational function approximation with variable transformation](https://www.researchgate.net/publication/346309410_Precise_and_fast_computation_of_Lambert_W_function_by_piecewise_minimax_rational_function_approximation_with_variable_transformation).
+#[must_use]
 pub fn sp_lambert_w0(z: f64) -> f64 {
     sw0::sw0(z)
 }


### PR DESCRIPTION
The action provided by the `cargo-semver-checks` repo spends a lot of time on an unknown step. This PR implements the same functionality manually.