### PR TITLE
Remove the `find-panic` profile and remove the `panic="abort"` setting from the `release-lto` profile.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Added a CI job that uses the above to ensure no panics make it into the crate.
  This verification can also be run manually on a local copy of the crate by
  setting the environment variable `LAMBERT_W_ENSURE_NO_PANICS` to 1 and
- then running `cargo test --profile find-panics`.
+ then running `cargo test --profile release-lto`.
 - Sped up the `semver-checks` CI job.
 - Removed the "no_std" category from the crate, as it's already in the
  "no_std::no_alloc" category, which is a subset of "no_std".

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,18 +37,11 @@ all-features = true
 [package.metadata.cargo-all-features]
 always_include_features = ["libm"]
 
-[profile.find-panics]
-inherits = "release"
-lto = "fat"
-codegen-units = 1
-
 [profile.release-lto]
 inherits = "release"
 lto = "fat"
 codegen-units = 1
 strip = "symbols"
-panic = "abort"
-incremental = false
 
 [[bench]]
 name = "random"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ always_include_features = ["libm"]
 inherits = "release"
 lto = "fat"
 codegen-units = 1
-strip = "symbols"
 
 [[bench]]
 name = "random"

--- a/build.rs
+++ b/build.rs
@@ -17,19 +17,19 @@ fn main() {
             // Enable the `assert_no_panic` cfg option.
             println!("cargo:rustc-cfg=assert_no_panic");
 
-            // This requires the `find-panics` profile to be enabled, otherwise it will result in false positives.
+            // This requires the `release-lto` profile to be enabled, otherwise it will result in false positives.
             // We emit a compilation warning if we can not determine that this profile is enabled.
             match parse_build_profile_name_from_environment() {
                 Ok(Some(profile_name)) => {
-                    if profile_name != "find-panics" {
-                        println!("cargo:warning=the `{ENV_KEY}` environment variable is set to 1, but a profile that could result in false positives seems to be enabled. False positives can be removed by enabling the \"find-panics\" profile.");
+                    if profile_name != "release-lto" {
+                        println!("cargo:warning=the `{ENV_KEY}` environment variable is set to 1, but a profile that could result in false positives seems to be enabled. False positives can be removed by enabling the \"release-lto\" profile.");
                     }
                 }
                 Ok(None) => {
-                    println!("cargo:warning=the `{ENV_KEY}` environment variable is set to 1, but the build profile name could not be determined. The \"find-panics\" profile must be enabled to ensure no false positives.");
+                    println!("cargo:warning=the `{ENV_KEY}` environment variable is set to 1, but the build profile name could not be determined. The \"release-lto\" profile must be enabled to ensure no false positives.");
                 }
                 Err(e) => {
-                    println!("cargo:warning=the `{ENV_KEY}` environment variable is set to 1, but the `OUT_DIR` environment variable could not be read due to: {e}\n The profile could therefore not be determined. The \"find-panics\" profile must be enabled to ensure no false positives.");
+                    println!("cargo:warning=the `{ENV_KEY}` environment variable is set to 1, but the `OUT_DIR` environment variable could not be read due to: {e}\n The profile could therefore not be determined. The \"release-lto\" profile must be enabled to ensure no false positives.");
                 }
             }
         }


### PR DESCRIPTION


Since the crate doensn't ever panic, we don't care if the panic isn't super optimized. This also means we have one less profile to keep track of.