### PR TITLE
Run the doctests in the readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Sped up the `semver-checks` CI job.
 - Removed the "no_std" category from the crate, as it's already in the
  "no_std::no_alloc" category, which is a subset of "no_std".
+- The doctests in the README are now ran during testing as well.
 
 ## 1.0.14
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ principal branch of the Lambert W function:
 
 ```rust
 use lambert_w::lambert_w0;
+use approx::assert_abs_diff_eq;
 
 let Ω = lambert_w0(1.0);
 
@@ -51,6 +52,7 @@ Evaluate the secondary branch of the Lambert W function at -ln(2)/2:
 
 ```rust
 use lambert_w::lambert_wm1;
+use approx::assert_abs_diff_eq;
 
 let mln4 = lambert_wm1(-f64::ln(2.0) / 2.0);
 
@@ -61,6 +63,7 @@ Do it on 32-bit floats:
 
 ```rust
 use lambert_w::{lambert_w0f, lambert_wm1f};
+use approx::assert_abs_diff_eq;
 
 let Ω = lambert_w0f(1.0);
 let mln4 = lambert_wm1f(-f32::ln(2.0) / 2.0);
@@ -73,6 +76,7 @@ The implementation can handle extreme inputs just as well:
 
 ```rust
 use lambert_w::{lambert_w0, lambert_wm1};
+use approx::assert_relative_eq;
 
 let big = lambert_w0(f64::MAX);
 let tiny = lambert_wm1(-1e-308);
@@ -85,6 +89,7 @@ Importing the `LambertW` trait lets you call the functions with postfix notation
 
 ```rust
 use lambert_w::LambertW;
+use approx::assert_abs_diff_eq;
 
 let z = 2.0 * f64::ln(2.0);
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ let z = 2.0 * f64::ln(2.0);
 assert_abs_diff_eq!(z.lambert_w0(), f64::ln(2.0));
 ```
 
+The crate used in the examples to verify the answers is [`approx`](https://crates.io/crates/approx).
+
 ## Features
 
 One of the below features must be enabled:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,12 @@
 #![no_std]
 #![forbid(unsafe_code)]
 
+// This struct does not exist in the public API
+// and is only used for running the doctests on the README.
+#[doc = include_str!("../README.md")]
+#[cfg(doctest)]
+pub struct ReadmeDoctests;
+
 #[cfg(feature = "std")]
 extern crate std;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,7 @@
 #![forbid(unsafe_code)]
 
 // This struct does not exist in the public API
-// and is only used for running the doctests on the README.
+// and is only used for running the doctests in the README.
 #[doc = include_str!("../README.md")]
 #[cfg(doctest)]
 pub struct ReadmeDoctests;


### PR DESCRIPTION
Using the code taken from <https://doc.rust-lang.org/rustdoc/write-documentation/documentation-tests.html#include-items-only-when-collecting-doctests>.