### PR TITLE
Move the test on random values last.

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -16,10 +16,6 @@ const RANDOM_TEST_SIZE: usize = 1_000_000;
 
 #[test]
 fn test_lambert_w0() {
-    let mut rng = SmallRng::seed_from_u64(1);
-    for _ in 0..RANDOM_TEST_SIZE {
-        assert!(lambert_w0(rng.random_range(NEG_INV_E..=f64::MAX)).is_finite());
-    }
     assert!(lambert_w0(NEG_INV_E - f64::EPSILON).is_nan());
     assert!(lambert_w0(f64::NAN).is_nan());
     assert_abs_diff_eq!(lambert_w0(NEG_INV_E), -1.0);
@@ -78,14 +74,15 @@ fn test_lambert_w0() {
         max_relative = 4e-16
     );
     assert_eq!(lambert_w0(f64::INFINITY), f64::INFINITY);
+
+    let mut rng = SmallRng::seed_from_u64(1);
+    for _ in 0..RANDOM_TEST_SIZE {
+        assert!(lambert_w0(rng.random_range(NEG_INV_E..=f64::MAX)).is_finite());
+    }
 }
 
 #[test]
 fn test_sp_lambert_w0() {
-    let mut rng = SmallRng::seed_from_u64(1);
-    for _ in 0..RANDOM_TEST_SIZE {
-        assert!(sp_lambert_w0(rng.random_range(NEG_INV_E..=f64::MAX)).is_finite());
-    }
     assert!(sp_lambert_w0(NEG_INV_E - f64::EPSILON).is_nan());
     assert!(sp_lambert_w0(f64::NAN).is_nan());
     assert_abs_diff_eq!(sp_lambert_w0(NEG_INV_E), -1.0, epsilon = 1e-7);
@@ -226,14 +223,15 @@ fn test_sp_lambert_w0() {
         max_relative = 1e-7,
     );
     assert_eq!(sp_lambert_w0(f64::INFINITY), f64::INFINITY);
+
+    let mut rng = SmallRng::seed_from_u64(1);
+    for _ in 0..RANDOM_TEST_SIZE {
+        assert!(sp_lambert_w0(rng.random_range(NEG_INV_E..=f64::MAX)).is_finite());
+    }
 }
 
 #[test]
 fn test_lambert_w0f() {
-    let mut rng = SmallRng::seed_from_u64(1);
-    for _ in 0..RANDOM_TEST_SIZE {
-        assert!(lambert_w0f(rng.random_range(NEG_INV_E as f32..=f32::MAX)).is_finite());
-    }
     assert!(lambert_w0f(NEG_INV_E as f32 - f32::EPSILON).is_nan());
     assert!(lambert_w0f(f32::NAN).is_nan());
     assert_abs_diff_eq!(lambert_w0f(NEG_INV_E as f32), -1.0);
@@ -261,14 +259,15 @@ fn test_lambert_w0f() {
     assert_relative_eq!(lambert_w0f(1e20), 4.230_675_5e1);
     assert_relative_eq!(lambert_w0f(f32::MAX), 84.288_59);
     assert_eq!(lambert_w0f(f32::INFINITY), f32::INFINITY);
+
+    let mut rng = SmallRng::seed_from_u64(1);
+    for _ in 0..RANDOM_TEST_SIZE {
+        assert!(lambert_w0f(rng.random_range(NEG_INV_E as f32..=f32::MAX)).is_finite());
+    }
 }
 
 #[test]
 fn test_lambert_wm1() {
-    let mut rng = SmallRng::seed_from_u64(1);
-    for _ in 0..RANDOM_TEST_SIZE {
-        assert!(lambert_wm1(rng.random_range(NEG_INV_E..0.0)).is_finite());
-    }
     assert!(lambert_wm1(NEG_INV_E - f64::EPSILON).is_nan());
     assert!(lambert_wm1(f64::NAN).is_nan());
     assert_abs_diff_eq!(lambert_wm1(NEG_INV_E), -1.0);
@@ -324,14 +323,15 @@ fn test_lambert_wm1() {
     );
     assert!(lambert_wm1(f64::EPSILON).is_nan());
     assert!(lambert_wm1(f64::INFINITY).is_nan());
+
+    let mut rng = SmallRng::seed_from_u64(1);
+    for _ in 0..RANDOM_TEST_SIZE {
+        assert!(lambert_wm1(rng.random_range(NEG_INV_E..0.0)).is_finite());
+    }
 }
 
 #[test]
 fn test_sp_lambert_wm1() {
-    let mut rng = SmallRng::seed_from_u64(1);
-    for _ in 0..RANDOM_TEST_SIZE {
-        assert!(sp_lambert_wm1(rng.random_range(NEG_INV_E..0.0)).is_finite());
-    }
     assert!(sp_lambert_wm1(NEG_INV_E - f64::EPSILON).is_nan());
     assert!(sp_lambert_wm1(f64::NAN).is_nan());
     assert_relative_eq!(sp_lambert_wm1(NEG_INV_E), -1.0, max_relative = 1e-7);
@@ -402,14 +402,15 @@ fn test_sp_lambert_wm1() {
     );
     assert!(sp_lambert_wm1(f64::EPSILON).is_nan());
     assert!(sp_lambert_wm1(f64::INFINITY).is_nan());
+
+    let mut rng = SmallRng::seed_from_u64(1);
+    for _ in 0..RANDOM_TEST_SIZE {
+        assert!(sp_lambert_wm1(rng.random_range(NEG_INV_E..0.0)).is_finite());
+    }
 }
 
 #[test]
 fn test_lambert_wm1f() {
-    let mut rng = SmallRng::seed_from_u64(1);
-    for _ in 0..RANDOM_TEST_SIZE {
-        assert!(lambert_wm1f(rng.random_range(NEG_INV_E as f32..0.0)).is_finite());
-    }
     assert!(lambert_wm1f(NEG_INV_E as f32 - f32::EPSILON).is_nan());
     assert!(lambert_wm1f(f32::NAN).is_nan());
     assert_abs_diff_eq!(lambert_wm1f(NEG_INV_E as f32), -1.0);
@@ -431,6 +432,11 @@ fn test_lambert_wm1f() {
     assert_relative_eq!(lambert_wm1f(-1e-20), -49.962_986);
     assert!(lambert_wm1f(f32::EPSILON).is_nan());
     assert!(lambert_wm1f(f32::INFINITY).is_nan());
+
+    let mut rng = SmallRng::seed_from_u64(1);
+    for _ in 0..RANDOM_TEST_SIZE {
+        assert!(lambert_wm1f(rng.random_range(NEG_INV_E as f32..0.0)).is_finite());
+    }
 }
 
 #[test]


### PR DESCRIPTION
This way the tests with a specific input can fail first.