### PR TITLE
Don't depend on specific patch versions of dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ documentation = "https://docs.rs/lambert_w"
 libm = { version = "0.2", optional = true }
 
 [dev-dependencies]
-approx = { version = "0.5.1", default-features = false }
-criterion = { version = "0.5.1", features = ["html_reports"] }
-rand = { version = "0.9.0", default-features = false, features = ["small_rng"] }
+approx = { version = "0.5", default-features = false }
+criterion = { version = "0.5", features = ["html_reports"] }
+rand = { version = "0.9", default-features = false, features = ["small_rng"] }
 plotters = { version = "0.3", default-features = false, features = ["bitmap_encoder", "bitmap_backend", "ttf"] }
 no-panic = "0.1"
 


### PR DESCRIPTION
Cargo will use the latest one anyway.