### PR TITLE
Inline the internal implementations of Fuskushima's paper into the public functions

### DIFF
--- a/src/dw0c.rs
+++ b/src/dw0c.rs
@@ -10,6 +10,7 @@ use crate::{
 // and f64::INFINITY if the input is positive infinity.
 
 /// zc = z + 1/e
+#[inline(always)]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn dw0c(zc: f64) -> f64 {
     if zc < 0.0 || zc.is_nan() {

--- a/src/dwm1c.rs
+++ b/src/dwm1c.rs
@@ -11,6 +11,7 @@ use crate::{
 // or if the `z` input is NAN, or larger than or equal to 0.
 
 /// zc = z + 1/e
+#[inline(always)]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn dwm1c(z: f64, zc: f64) -> f64 {
     if zc < 0.0 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,6 @@ pub const OMEGA: f64 = 0.567_143_290_409_783_8;
 // the `assert_no_panic` attribute if that variable is set.
 // We then check for that attribute when testing and if so we statically ensure that no
 // function in the crate can panic using the `no-panic` crate.
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn sp_lambert_w0(z: f64) -> f64 {
     sw0::sw0(z)
@@ -102,7 +101,6 @@ pub fn sp_lambert_w0(z: f64) -> f64 {
 /// # Reference
 ///
 /// [Toshio Fukushima, Precise and fast computation of Lambert W function by piecewise minimax rational function approximation with variable transformation](https://www.researchgate.net/publication/346309410_Precise_and_fast_computation_of_Lambert_W_function_by_piecewise_minimax_rational_function_approximation_with_variable_transformation).
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn sp_lambert_wm1(z: f64) -> f64 {
     swm1::swm1(z)
@@ -133,7 +131,6 @@ pub fn sp_lambert_wm1(z: f64) -> f64 {
 /// # Reference
 ///
 /// [Toshio Fukushima, Precise and fast computation of Lambert W function by piecewise minimax rational function approximation with variable transformation](https://www.researchgate.net/publication/346309410_Precise_and_fast_computation_of_Lambert_W_function_by_piecewise_minimax_rational_function_approximation_with_variable_transformation).
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn lambert_w0(z: f64) -> f64 {
     dw0c::dw0c(z - NEG_INV_E)
@@ -168,7 +165,6 @@ pub fn lambert_w0(z: f64) -> f64 {
 /// # Reference
 ///
 /// [Toshio Fukushima, Precise and fast computation of Lambert W function by piecewise minimax rational function approximation with variable transformation](https://www.researchgate.net/publication/346309410_Precise_and_fast_computation_of_Lambert_W_function_by_piecewise_minimax_rational_function_approximation_with_variable_transformation).
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn lambert_w0f(z: f32) -> f32 {
     sw0f::sw0f(z)
@@ -200,7 +196,6 @@ pub fn lambert_w0f(z: f32) -> f32 {
 /// # Reference
 ///
 /// [Toshio Fukushima, Precise and fast computation of Lambert W function by piecewise minimax rational function approximation with variable transformation](https://www.researchgate.net/publication/346309410_Precise_and_fast_computation_of_Lambert_W_function_by_piecewise_minimax_rational_function_approximation_with_variable_transformation).
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn lambert_wm1(z: f64) -> f64 {
     dwm1c::dwm1c(z, z - NEG_INV_E)
@@ -236,7 +231,6 @@ pub fn lambert_wm1(z: f64) -> f64 {
 /// # Reference
 ///
 /// [Toshio Fukushima, Precise and fast computation of Lambert W function by piecewise minimax rational function approximation with variable transformation](https://www.researchgate.net/publication/346309410_Precise_and_fast_computation_of_Lambert_W_function_by_piecewise_minimax_rational_function_approximation_with_variable_transformation).
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn lambert_wm1f(z: f32) -> f32 {
     swm1f::swm1f(z)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,7 @@ pub const OMEGA: f64 = 0.567_143_290_409_783_8;
 // the `assert_no_panic` attribute if that variable is set.
 // We then check for that attribute when testing and if so we statically ensure that no
 // function in the crate can panic using the `no-panic` crate.
+#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn sp_lambert_w0(z: f64) -> f64 {
     sw0::sw0(z)
@@ -101,6 +102,7 @@ pub fn sp_lambert_w0(z: f64) -> f64 {
 /// # Reference
 ///
 /// [Toshio Fukushima, Precise and fast computation of Lambert W function by piecewise minimax rational function approximation with variable transformation](https://www.researchgate.net/publication/346309410_Precise_and_fast_computation_of_Lambert_W_function_by_piecewise_minimax_rational_function_approximation_with_variable_transformation).
+#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn sp_lambert_wm1(z: f64) -> f64 {
     swm1::swm1(z)
@@ -131,6 +133,7 @@ pub fn sp_lambert_wm1(z: f64) -> f64 {
 /// # Reference
 ///
 /// [Toshio Fukushima, Precise and fast computation of Lambert W function by piecewise minimax rational function approximation with variable transformation](https://www.researchgate.net/publication/346309410_Precise_and_fast_computation_of_Lambert_W_function_by_piecewise_minimax_rational_function_approximation_with_variable_transformation).
+#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn lambert_w0(z: f64) -> f64 {
     dw0c::dw0c(z - NEG_INV_E)
@@ -165,6 +168,7 @@ pub fn lambert_w0(z: f64) -> f64 {
 /// # Reference
 ///
 /// [Toshio Fukushima, Precise and fast computation of Lambert W function by piecewise minimax rational function approximation with variable transformation](https://www.researchgate.net/publication/346309410_Precise_and_fast_computation_of_Lambert_W_function_by_piecewise_minimax_rational_function_approximation_with_variable_transformation).
+#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn lambert_w0f(z: f32) -> f32 {
     sw0f::sw0f(z)
@@ -196,6 +200,7 @@ pub fn lambert_w0f(z: f32) -> f32 {
 /// # Reference
 ///
 /// [Toshio Fukushima, Precise and fast computation of Lambert W function by piecewise minimax rational function approximation with variable transformation](https://www.researchgate.net/publication/346309410_Precise_and_fast_computation_of_Lambert_W_function_by_piecewise_minimax_rational_function_approximation_with_variable_transformation).
+#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn lambert_wm1(z: f64) -> f64 {
     dwm1c::dwm1c(z, z - NEG_INV_E)
@@ -231,6 +236,7 @@ pub fn lambert_wm1(z: f64) -> f64 {
 /// # Reference
 ///
 /// [Toshio Fukushima, Precise and fast computation of Lambert W function by piecewise minimax rational function approximation with variable transformation](https://www.researchgate.net/publication/346309410_Precise_and_fast_computation_of_Lambert_W_function_by_piecewise_minimax_rational_function_approximation_with_variable_transformation).
+#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn lambert_wm1f(z: f32) -> f32 {
     swm1f::swm1f(z)

--- a/src/sw0.rs
+++ b/src/sw0.rs
@@ -10,6 +10,7 @@ use crate::{
 // It returns f64::NAN if the input is negative or NAN,
 // and f64::INFINITY if the input is positive infinity.
 
+#[inline(always)]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn sw0(z: f64) -> f64 {
     if z < NEG_INV_E || z.is_nan() {

--- a/src/sw0f.rs
+++ b/src/sw0f.rs
@@ -11,6 +11,7 @@ const NEG_INV_E: f32 = super::NEG_INV_E as f32;
 // It returns f32::NAN if the input is negative or NAN,
 // and f32::INFINITY if the input is positive infinity.
 
+#[inline(always)]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn sw0f(z: f32) -> f32 {
     if z < NEG_INV_E || z.is_nan() {

--- a/src/swm1.rs
+++ b/src/swm1.rs
@@ -9,6 +9,7 @@ use crate::{
 // with 24 bits of accuracy from Fukushima's paper.
 // It returns f64::NAN if the input is smaller than -1/e, is NAN, or is larger than or equal to 0.
 
+#[inline(always)]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn swm1(z: f64) -> f64 {
     if z < NEG_INV_E {

--- a/src/swm1f.rs
+++ b/src/swm1f.rs
@@ -11,6 +11,7 @@ const NEG_INV_E: f32 = super::NEG_INV_E as f32;
 // with 24 bits of accuracy from Fukushima's paper.
 // It returns f32::NAN if the input is smaller than -1/e, is NAN, or is larger than or equal to 0.
 
+#[inline(always)]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn swm1f(z: f32) -> f32 {
     if z < NEG_INV_E {


### PR DESCRIPTION
This way there should not be an extra indirection step.

Each one is also only used in a single location, so there will be no code bloat from using inline(always).