### PR TITLE
Add a check on no_std targets in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -179,3 +179,19 @@ jobs:
       run: echo "LAMBERT_W_ENSURE_NO_PANICS=1" >> $GITHUB_ENV
     - name: Check the crate for panics
       run: cargo test-all-features --profile release-lto
+
+  no_std:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [thumbv7m-none-eabi, aarch64-unknown-none]
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        target: &{{ matrix.target }}
+    - uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-all-features
+    - name: Check no_std targets
+      run: cargo check-all-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -193,5 +193,7 @@ jobs:
     - uses: taiki-e/install-action@v2
       with:
         tool: cargo-all-features
-    - name: Check all feature combinations on ${{ matrix.target }}
+    - name: Check all feature combinations
       run: cargo check-all-features
+    - name: Build all feature combinations
+      run: cargo build-all-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -191,6 +191,6 @@ jobs:
       with:
         target: ${{ matrix.target }}
     - name: Check
-      run: cargo check
+      run: cargo check --target ${{ matrix.target }}
     - name: Build
-      run: cargo build
+      run: cargo build --target ${{ matrix.target }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -193,5 +193,5 @@ jobs:
     - uses: taiki-e/install-action@v2
       with:
         tool: cargo-all-features
-    - name: Check no_std targets
+    - name: Check all feature combinations on ${{ matrix.target }}
       run: cargo check-all-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -190,10 +190,7 @@ jobs:
     - uses: dtolnay/rust-toolchain@stable
       with:
         target: ${{ matrix.target }}
-    - uses: taiki-e/install-action@v2
-      with:
-        tool: cargo-all-features
-    - name: Check all feature combinations
-      run: cargo check-all-features
-    - name: Build all feature combinations
-      run: cargo build-all-features
+    - name: Check
+      run: cargo check
+    - name: Build
+      run: cargo build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -189,7 +189,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
       with:
-        target: &{{ matrix.target }}
+        target: ${{ matrix.target }}
     - uses: taiki-e/install-action@v2
       with:
         tool: cargo-all-features


### PR DESCRIPTION
This job runs cargo check and cargo build on targets that do not have a standard library.