### PR TITLE
Add a check of minimal versions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -230,5 +230,5 @@ jobs:
         run: rustup default stable
       - name: cargo update -Zminimal-versions
         run: cargo +nightly update -Zminimal-versions
-      - name: cargo test
-        run: cargo test-all-features --locked
+      - name: Check all feature combinations
+        run: cargo check-all-features --locked


### PR DESCRIPTION
This adds a CI job that sets all the dependencies to the oldest version compatible with what is specified in all the `Cargo.toml` files across the dependency tree, and then runs `cargo check`. Taken from https://github.com/jonhoo/rust-ci-conf/blob/main/.github/workflows/test.yml#L85.