### PR TITLE
Undeprecate the `LambertW` trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Added the `must_use` attribute to all pure functions.
 - Added the [`num-traits`](https://crates.io/crates/num-traits) and
  [`num-complex`](https://crates.io/crates/num-complex) crates to dependencies.
-- Deprecated the `LambertW` trait, as this crate is not really the place for
- such API decisions to be made on behalf of others.
  It is also unclear how the trait should be defined given the newly introduced
  general implementation.
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,17 @@ assert_relative_eq!(
 );
 ```
 
+Importing the LambertW trait lets you call the functions with postfix notation:
+
+```rust
+use lambert_w::LambertW;
+use approx::assert_abs_diff_eq;
+
+let ln1k = (1000.0 * f64::ln(1000.0)).lambert_w0();
+
+assert_abs_diff_eq!(ln1k, f64::ln(1000.0));
+```
+
 The macros in the examples above are from the [`approx`](https://docs.rs/approx/latest/approx/)
 crate, and are used in the documentation examples of this crate.
 The assertion passes if the two supplied values are the same to within floating

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,10 +247,6 @@ pub fn lambert_wm1f(z: f32) -> f32 {
 
 /// Enables evaluation of the principal and secondary branches of the Lambert W function
 /// on the types that implement this trait.
-#[deprecated(
-    since = "1.1.0",
-    note = "use the functions directly or create your own trait, the `lambert_w` crate is not the place for making such API decisions for others."
-)]
 pub trait LambertW {
     /// The type returned by the Lambert W functions when acting on a value of type `Self`.
     type Output;
@@ -262,7 +258,6 @@ pub trait LambertW {
     fn lambert_wm1(self) -> Self::Output;
 }
 
-#[allow(deprecated)]
 impl LambertW for f32 {
     type Output = Self;
     /// The principal branch of the Lambert W function.
@@ -289,7 +284,6 @@ impl LambertW for f32 {
     }
 }
 
-#[allow(deprecated)]
 impl LambertW for f64 {
     type Output = Self;
     /// The principal branch of the Lambert W function evaluated to 50 bits of accuracy.


### PR DESCRIPTION
There might be a better way to do this. Must think.