### PR TITLE
Remove `libm` as a direct dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 This file contains the changes to the crate since version 0.1.1.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.2.5 (unreleased)
+
+- Remove `libm` as a direct dependency. It is only used through the `num-traits`
+ and `num-complex` crates now.
+
 ## 1.2.4
 
 - Improvements to docs.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,7 +506,6 @@ version = "1.2.4"
 dependencies = [
  "approx",
  "criterion",
- "libm",
  "no-panic",
  "num-complex",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ repository = "https://github.com/JSorngard/lambert_w"
 documentation = "https://docs.rs/lambert_w"
 
 [dependencies]
-libm = { version = "0.2.11", optional = true }
 num-complex = { version = "0.4.6", default-features = false }
 num-traits = { version = "0.2.19", default-features = false }
 
@@ -27,7 +26,7 @@ no-panic = "0.1"
 default = ["libm"]
 # If the `std` feature is disabled, this feature uses the [`libm`](https://crates.io/crates/libm) crate
 # to compute square roots and logarithms during function evaluation instead of the standard library.
-libm = ["dep:libm", "num-traits/libm", "num-complex/libm"]
+libm = ["num-traits/libm", "num-complex/libm"]
 # Use the standard library to compute square roots and logarithms for a potential performance gain.
 # When this feature is disabled the crate is `no_std` compatible.
 std = ["num-traits/std", "num-complex/std"]


### PR DESCRIPTION
Since we only use it through `num-traits` and `num-complex`.