### PR TITLE
Shrink size of the iteration count

### DIFF
--- a/src/all_complex_branches.rs
+++ b/src/all_complex_branches.rs
@@ -11,7 +11,7 @@ use core::{
 
 use crate::NEG_INV_E;
 
-const MAX_ITER: usize = 30;
+const MAX_ITER: u8 = 30;
 /// If the absolute difference between two consecutive iterations is less than this value,
 /// the iteration stops.
 const PREC: f64 = 1e-30;


### PR DESCRIPTION
We only need to count to 30, so a `u8` is sufficient.