### PR TITLE
Add reference benchmarks to random benches

### DIFF
--- a/benches/random.rs
+++ b/benches/random.rs
@@ -49,6 +49,26 @@ fn bench_on_vec_of_random_values_in_range<'a, R, T, F, U, Prng>(
 fn random_benches(c: &mut Criterion) {
     let mut rng = SmallRng::seed_from_u64(0b1010101010101);
 
+    let reference_group = c.benchmark_group("random inputs (Reference)");
+
+    bench_on_vec_of_random_values(
+        &mut reference_group,
+        "ln",
+        |x| x.ln(),
+        0.1..=f64::from(u32::MAX),
+        &mut rng, 
+    );
+
+    bench_on_vec_of_random_values(
+        &mut reference_group,
+        "sqrt",
+        |x| x.sqrt(),
+        0.1..=f64::from(u32::MAX),
+        &mut rng, 
+    );
+
+    drop(reference_group);
+
     let mut halley_group = c.benchmark_group("random inputs (Halley's method)");
 
     bench_on_vec_of_random_values_in_range(

--- a/benches/random.rs
+++ b/benches/random.rs
@@ -51,7 +51,7 @@ fn random_benches(c: &mut Criterion) {
 
     let reference_group = c.benchmark_group("random inputs (Reference)");
 
-    bench_on_vec_of_random_values(
+    bench_on_vec_of_random_values_in_range(
         &mut reference_group,
         "ln",
         |x| x.ln(),
@@ -59,7 +59,7 @@ fn random_benches(c: &mut Criterion) {
         &mut rng,
     );
 
-    bench_on_vec_of_random_values(
+    bench_on_vec_of_random_values_in_range(
         &mut reference_group,
         "sqrt",
         |x| x.sqrt(),

--- a/benches/random.rs
+++ b/benches/random.rs
@@ -49,7 +49,7 @@ fn bench_on_vec_of_random_values_in_range<'a, R, T, F, U, Prng>(
 fn random_benches(c: &mut Criterion) {
     let mut rng = SmallRng::seed_from_u64(0b1010101010101);
 
-    let reference_group = c.benchmark_group("random inputs (Reference)");
+    let mut reference_group = c.benchmark_group("random inputs (Reference)");
 
     bench_on_vec_of_random_values_in_range(
         &mut reference_group,

--- a/benches/random.rs
+++ b/benches/random.rs
@@ -56,7 +56,7 @@ fn random_benches(c: &mut Criterion) {
         "ln",
         |x| x.ln(),
         0.1..=f64::from(u32::MAX),
-        &mut rng, 
+        &mut rng,
     );
 
     bench_on_vec_of_random_values(
@@ -64,7 +64,7 @@ fn random_benches(c: &mut Criterion) {
         "sqrt",
         |x| x.sqrt(),
         0.1..=f64::from(u32::MAX),
-        &mut rng, 
+        &mut rng,
     );
 
     drop(reference_group);


### PR DESCRIPTION
This adds benchmarks of the logarithm and square root implementations that the crate relies on to the benchmarks on random inputs.

This way we can compare the runtime of the Lambert W functions with the fundamental pieces they rely on. 