### PR TITLE
Add shortened license info to the top of each source file

### DIFF
--- a/benches/fixed.rs
+++ b/benches/fixed.rs
@@ -1,3 +1,5 @@
+// Copyright 2024 Johanna Sörngård
+// SPDX-License-Identifier: MIT OR Apache-2.0
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use lambert_w::{
     lambert_w, lambert_w0, lambert_w0f, lambert_wm1, lambert_wm1f, sp_lambert_w0, sp_lambert_wm1,

--- a/benches/random.rs
+++ b/benches/random.rs
@@ -1,3 +1,5 @@
+// Copyright 2024 Johanna Sörngård
+// SPDX-License-Identifier: MIT OR Apache-2.0
 use core::ops::RangeBounds;
 use criterion::{
     black_box, criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion,

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,5 @@
+// Copyright 2024 Johanna Sörngård
+// SPDX-License-Identifier: MIT OR Apache-2.0
 use std::env;
 
 fn main() {

--- a/examples/plot.rs
+++ b/examples/plot.rs
@@ -1,3 +1,5 @@
+// Copyright 2024 Johanna Sörngård
+// SPDX-License-Identifier: MIT OR Apache-2.0
 //! This example is intended to be ran more than studied.
 //! It generates a plot of the two branches of the function
 //! and saves it as a png file.

--- a/src/all_complex_branches.rs
+++ b/src/all_complex_branches.rs
@@ -1,3 +1,5 @@
+// Copyright 2024 Johanna Sörngård
+// SPDX-License-Identifier: MIT OR Apache-2.0
 //! This module contains the general implementation of the Lambert W function.
 //! This implementation is capable of computing the function at any point in the complex plane on any branch.
 

--- a/src/dw0c.rs
+++ b/src/dw0c.rs
@@ -1,3 +1,5 @@
+// Copyright 2024 Johanna Sörngård
+// SPDX-License-Identifier: MIT OR Apache-2.0
 //! This module contains an implementation of the approximation of the principal
 //! branch of the Lambert W function
 //! with 50 bits of accuracy from Fukushima's paper.

--- a/src/dwm1c.rs
+++ b/src/dwm1c.rs
@@ -1,3 +1,5 @@
+// Copyright 2024 Johanna Sörngård
+// SPDX-License-Identifier: MIT OR Apache-2.0
 //! This module contains an implementation of the approximation of the secondary
 //! branch of the Lambert W function
 //! with 50 bits of accuracy from Fukushima's paper.

--- a/src/generic_math.rs
+++ b/src/generic_math.rs
@@ -1,3 +1,5 @@
+// Copyright 2024 Johanna Sörngård
+// SPDX-License-Identifier: MIT OR Apache-2.0
 //! This module contains elementary and rational functions used in the Lambert W function approximations.
 //! They are generic over all types that implement the [`Float`] trait.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright 2024 Johanna Sörngård
+// SPDX-License-Identifier: MIT OR Apache-2.0 
+
 #![doc = include_str!("../README.md")]
 #![no_std]
 #![forbid(unsafe_code)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 // Copyright 2024 Johanna Sörngård
-// SPDX-License-Identifier: MIT OR Apache-2.0 
+// SPDX-License-Identifier: MIT OR Apache-2.0
 
 #![doc = include_str!("../README.md")]
 #![no_std]

--- a/src/sw0.rs
+++ b/src/sw0.rs
@@ -1,3 +1,5 @@
+// Copyright 2024 Johanna Sörngård
+// SPDX-License-Identifier: MIT OR Apache-2.0
 //! This module contains an implementation of the approximation of the principal
 //! branch of the Lambert W function
 //! with 24 bits of accuracy from Fukushima's paper.

--- a/src/sw0f.rs
+++ b/src/sw0f.rs
@@ -1,3 +1,5 @@
+// Copyright 2024 Johanna Sörngård
+// SPDX-License-Identifier: MIT OR Apache-2.0
 //! This module contains an implementation of the approximation of the principal
 //! branch of the Lambert W function
 //! with 24 bits of accuracy from Fukushima's paper.

--- a/src/swm1.rs
+++ b/src/swm1.rs
@@ -1,3 +1,5 @@
+// Copyright 2024 Johanna Sörngård
+// SPDX-License-Identifier: MIT OR Apache-2.0
 //! This module contains an implementation of the approximation of the secondary
 //! branch of the Lambert W function
 //! with 24 bits of accuracy from Fukushima's paper.

--- a/src/swm1f.rs
+++ b/src/swm1f.rs
@@ -1,3 +1,5 @@
+// Copyright 2024 Johanna Sörngård
+// SPDX-License-Identifier: MIT OR Apache-2.0
 //! This module contains an implementation of the approximation of the secondary
 //! branch of the Lambert W function
 //! with 24 bits of accuracy from Fukushima's paper.

--- a/src/unit_tests.rs
+++ b/src/unit_tests.rs
@@ -1,3 +1,5 @@
+// Copyright 2024 Johanna Sörngård
+// SPDX-License-Identifier: MIT OR Apache-2.0
 //! This file contains unit tests for non-public functions.
 
 use crate::generic_math::{ln, rational_function, sqrt};

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,3 +1,5 @@
+// Copyright 2024 Johanna Sörngård
+// SPDX-License-Identifier: MIT OR Apache-2.0
 //! This file contains tests of the public API of the crate.
 //!
 //! Every test function utilizes [`assert_abs_diff_eq!`] for as long as possible,


### PR DESCRIPTION
This is recommend by the Apache foundation: https://apache.org/foundation/license-faq.html#Apply-My-Software