### PR TITLE
Include fewer files in the package sent to crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ rust-version = "1.63.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/JSorngard/lambert_w"
 documentation = "https://docs.rs/lambert_w"
+exclude = ["examples/", "benches/", "tests/", "src/unit_tests.rs"]
 
 [dependencies]
 num-complex = { version = "0.4.6", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.63.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/JSorngard/lambert_w"
 documentation = "https://docs.rs/lambert_w"
-exclude = ["examples/", "benches/", "tests/", "src/unit_tests.rs"]
+exclude = ["examples/", "benches/", "tests/", "src/unit_tests.rs", ".github/", ".gitignore"]
 
 [dependencies]
 num-complex = { version = "0.4.6", default-features = false }


### PR DESCRIPTION
Specifically we will not include files that are cfg'ed out when just depending on the crate normally.