### PR TITLE
Include more of the omega constant digits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 1.2.21 (unreleased)
 
-- Include more digits in the omega constant.
+- Include more digits in the omega constant for clarity.
 
 ## 1.2.20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file contains the changes to the crate since version 0.1.1.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.2.21 (unreleased)
+
+- Include more digits in the omega constant.
+
 ## 1.2.20
 
 - Updated the copyright year in the source files to 2025.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ use approx::assert_abs_diff_eq;
 
 let Ω = lambert_w0(1.0);
 
-assert_abs_diff_eq!(Ω, 0.5671432904097839);
+assert_abs_diff_eq!(Ω, 0.567143290409783873);
 assert_abs_diff_eq!(Ω * f64::exp(Ω), 1.0);
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ const INV_SQRT_E: f64 = 0.606_530_659_712_633_4;
 ///
 /// Fulfills the equation Ωe^Ω = 1.
 // We include more digits than fit in an f64 because if we write
-// 0.567_143_290_409_783_8 (clippy's suggestion without excessive precision) 
+// 0.567_143_290_409_783_8 (clippy's suggestion without excessive precision)
 // it looks as if we have rounded it incorrectly,
 // since the correctly rounded value to that many digits would be
 // 0.567_143_290_409_783_9.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,13 +41,8 @@ const INV_SQRT_E: f64 = 0.606_530_659_712_633_4;
 /// The omega constant (Ω).
 ///
 /// Fulfills the equation Ωe^Ω = 1.
-///
-/// Has been rounded to the closest available `f64` value.
-//        Rounded from 0.567_143_290_409_783_87
-pub const OMEGA: f64 = 0.567_143_290_409_783_8;
-// If we round the last two digits (87) to 9 rustc sets the constant to
-//                     0.567_143_290_409_784
-// which is further away from the true value than what we get if we round them to 8.
+#[allow(clippy::excessive_precision)]
+pub const OMEGA: f64 = 0.567_143_290_409_783_873;
 
 /// The principal branch of the Lambert W function computed to 50 bits of accuracy on 64-bit floats with Fukushima's method.
 ///
@@ -61,7 +56,7 @@ pub const OMEGA: f64 = 0.567_143_290_409_783_8;
 ///
 /// let Ω = lambert_w0(1.0);
 ///
-/// assert_abs_diff_eq!(Ω, 0.5671432904097839);
+/// assert_abs_diff_eq!(Ω, 0.567143290409783873);
 /// ```
 ///
 /// Arguments smaller than -1/e (≈ -0.36787944117144233) result in [`NAN`](f64::NAN):

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,17 @@ const INV_SQRT_E: f64 = 0.606_530_659_712_633_4;
 /// The omega constant (Ω).
 ///
 /// Fulfills the equation Ωe^Ω = 1.
+// We include more digits than fit in an f64 because if we write
+// 0.567_143_290_409_783_8 (clippy's suggestion without excessive precision) 
+// it looks as if we have rounded it incorrectly,
+// since the correctly rounded value to that many digits would be
+// 0.567_143_290_409_783_9.
+// However, if we write the correctly rounded value the compiler rounds it to
+// 0.567_143_290_409_784, which is further from the true value than
+// 0.567_143_290_409_783_8.
+// To avoid all this confusion for any potential readers of the docs
+// we just add more digits so that the compiler rounds it correctly and then
+// allow the clippy lint.
 #[allow(clippy::excessive_precision)]
 pub const OMEGA: f64 = 0.567_143_290_409_783_873;
 


### PR DESCRIPTION
This way cargo rounds it correctly, unlike before where we had to explicitly write a value that looked wrong in order for the compiler to round it to the correct value.

We just need to allow the excessive_precision clippy lint for that constant.