### PR TITLE
Hide header and footer of readme on docs.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Updated the criterion dev-dependency.
 - Internal code structure improvements.
 - Documentation improvements.
+- Hide the crate name, badges and license sections of the readme on docs.rs.
 
 ## 1.2.21
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 <div class = "rustdoc-hidden">
+
 # lambert_w
 
 [![Crates.io Version](https://img.shields.io/crates/v/lambert_w?logo=rust)](https://crates.io/crates/lambert_w)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<div class = "rustdoc-hidden">
 # lambert_w
 
 [![Crates.io Version](https://img.shields.io/crates/v/lambert_w?logo=rust)](https://crates.io/crates/lambert_w)
@@ -6,6 +7,8 @@
 [![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/JSorngard/lambert_w/rust.yml?logo=github&label=CI)](https://github.com/JSorngard/lambert_w/actions/workflows/rust.yml)
 [![Code Coverage](https://codecov.io/gh/JSorngard/lambert_w/graph/badge.svg?token=F61FO63ZKW)](https://codecov.io/gh/JSorngard/lambert_w)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/10491/badge)](https://www.bestpractices.dev/projects/10491)
+
+</div>
 
 This crate provides fast and accurate evaluation of the real valued parts of the
 principal and secondary branches of the [Lambert W function](https://en.wikipedia.org/wiki/Lambert_W_function),
@@ -152,6 +155,8 @@ November 2020.
 
 [⬆️ Back to top](#lambert_w).
 
+<div class = "rustdoc-hidden">
+
 <br>
 
 ### License
@@ -168,3 +173,5 @@ Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
 </sub>
+
+</div>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 
 
 // This style is used in the readme itself to hide specific parts of it when rendered on docs.rs.
-// This idea is taken from <https://linebender.org/blog/doc-include>. 
+// This idea is taken from <https://linebender.org/blog/doc-include>.
 //! <style>
 //! .rustdoc-hidden { display: none; }
 //! </style>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 
+// This style is used in the readme itself to hide specific parts of it when rendered on docs.rs.
+// This idea is taken from <https://linebender.org/blog/doc-include>. 
 //! <style>
 //! .rustdoc-hidden { display: none; }
 //! </style>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 // Copyright 2025 Johanna Sörngård
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-
 // This style is used in the readme itself to hide specific parts of it when rendered on docs.rs.
 // This idea is taken from <https://linebender.org/blog/doc-include>.
 //! <style>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,10 @@
 // Copyright 2025 Johanna Sörngård
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+
+//! <style>
+//! .rustdoc-hidden { display: none; }
+//! </style>
 #![doc = include_str!("../README.md")]
 #![no_std]
 #![forbid(unsafe_code)]


### PR DESCRIPTION
Idea taken from <https://linebender.org/blog/doc-include>.