### PR TITLE
Use fused multiply-add instructions when present on the target architecture.

### DIFF
--- a/src/generic_math.rs
+++ b/src/generic_math.rs
@@ -40,18 +40,18 @@ fn polynomial<T: Float, const N: usize>(x: T, coefficients: [T; N]) -> T {
         .fold(T::zero(), |acc, c| mul_add(acc, x, c))
 }
 
-#[cfg(not(target_feature = "fma"))]
 #[inline(always)]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 fn mul_add<T: Float>(acc: T, x: T, c: T) -> T {
-    acc * x + c
-}
+    #[cfg(not(target_feature = "fma"))]
+    {
+        acc * x + c
+    }
 
-#[cfg(target_feature = "fma")]
-#[inline(always)]
-#[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-fn mul_add<T: Float>(acc: T, x: T, c: T) -> T {
-    acc.mul_add(x, c)
+    #[cfg(target_feature = "fma")]
+    {
+        acc.mul_add(x, c)
+    }
 }
 
 // The functions below are wrappers around the [`num-traits`] crate,

--- a/src/generic_math.rs
+++ b/src/generic_math.rs
@@ -41,13 +41,13 @@ fn polynomial<T: Float, const N: usize>(x: T, coefficients: [T; N]) -> T {
 
 #[cfg(not(target_feature = "fma"))]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-fn mul_add<T: Float>(acc, x, c) -> T {
+fn mul_add<T: Float>(acc: T, x: T, c: T) -> T {
     acc * x + c
 }
 
 #[cfg(target_feature = "fma")]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-fn mul_add<T: Float>(acc, x, c) -> T {
+fn mul_add<T: Float>(acc: T, x: T, c: T) -> T {
     acc.mul_add(x, c)
 }
 

--- a/src/generic_math.rs
+++ b/src/generic_math.rs
@@ -40,6 +40,10 @@ fn polynomial<T: Float, const N: usize>(x: T, coefficients: [T; N]) -> T {
         .fold(T::zero(), |acc, c| mul_add(acc, x, c))
 }
 
+/// Multiply `acc` by `x` and add `c` to the result.
+///
+/// If the target supports the Fused Multiply-Add (FMA) instruction,
+/// this will use it for better performance and accuracy.
 #[inline(always)]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 fn mul_add<T: Float>(acc: T, x: T, c: T) -> T {

--- a/src/generic_math.rs
+++ b/src/generic_math.rs
@@ -36,6 +36,8 @@ pub fn rational_function<T: Float, const N: usize, const D: usize>(
     numerator / denominator
 }
 
+#[inline(always)]
+#[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 #[cfg(target_feature = "fma")]
 pub fn rational_function<T: Float, const N: usize, const D: usize>(
     x: T,

--- a/src/generic_math.rs
+++ b/src/generic_math.rs
@@ -31,6 +31,7 @@ pub fn rational_function<T: Float, const N: usize, const D: usize>(
 /// Evaluate a polynomial at `x` using Horner's method.
 ///
 /// The coefficients are assumed to be sorted in ascending order by degree.
+#[inline(always)]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 fn polynomial<T: Float, const N: usize>(x: T, coefficients: [T; N]) -> T {
     coefficients
@@ -40,12 +41,14 @@ fn polynomial<T: Float, const N: usize>(x: T, coefficients: [T; N]) -> T {
 }
 
 #[cfg(not(target_feature = "fma"))]
+#[inline(always)]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 fn mul_add<T: Float>(acc: T, x: T, c: T) -> T {
     acc * x + c
 }
 
 #[cfg(target_feature = "fma")]
+#[inline(always)]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 fn mul_add<T: Float>(acc: T, x: T, c: T) -> T {
     acc.mul_add(x, c)

--- a/src/generic_math.rs
+++ b/src/generic_math.rs
@@ -17,6 +17,7 @@ use num_traits::Float;
 // of the functions with 50 bits of accuracy.
 #[inline(always)]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
+#[cfg(not(target_feature = "fma"))]
 pub fn rational_function<T: Float, const N: usize, const D: usize>(
     x: T,
     numerator_coefficients: [T; N],
@@ -34,6 +35,26 @@ pub fn rational_function<T: Float, const N: usize, const D: usize>(
 
     numerator / denominator
 }
+
+#[cfg(target_feature = "fma")]
+pub fn rational_function<T: Float, const N: usize, const D: usize>(
+    x: T,
+    numerator_coefficients: [T; N],
+    denominator_coefficients: [T; D],
+) -> T {
+    let numerator = numerator_coefficients
+        .into_iter()
+        .rev()
+        .fold(T::zero(), |acc, n| acc.mul_add(x, n));
+
+    let denominator = denominator_coefficients
+        .into_iter()
+        .rev()
+        .fold(T::zero(), |acc, d| acc.mul_add(x, d));
+
+    numerator / denominator
+}
+
 
 // The functions below are wrappers around the [`num-traits`] crate,
 // mainly to ensure that we can always call them regardless of the presence of

--- a/src/generic_math.rs
+++ b/src/generic_math.rs
@@ -10,6 +10,7 @@ use num_traits::Float;
 // I have only benchmarked the functions on my own system with a CPU with large cache
 // and I am not sure if the inlining is beneficial on all systems, and for all users.
 
+#[cfg(not(target_feature = "fma"))]
 /// Evaluate a rational function at `x` using Horner's method.
 ///
 /// The coefficients are assumed to be sorted in ascending order by degree.
@@ -17,7 +18,6 @@ use num_traits::Float;
 // of the functions with 50 bits of accuracy.
 #[inline(always)]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-#[cfg(not(target_feature = "fma"))]
 pub fn rational_function<T: Float, const N: usize, const D: usize>(
     x: T,
     numerator_coefficients: [T; N],
@@ -36,9 +36,13 @@ pub fn rational_function<T: Float, const N: usize, const D: usize>(
     numerator / denominator
 }
 
+#[cfg(target_feature = "fma")]
+/// Evaluate a rational function at `x` using Horner's method.
+/// The function uses fused multiply-add instructions for better performance.
+///
+/// The coefficients are assumed to be sorted in ascending order by degree.
 #[inline(always)]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-#[cfg(target_feature = "fma")]
 pub fn rational_function<T: Float, const N: usize, const D: usize>(
     x: T,
     numerator_coefficients: [T; N],


### PR DESCRIPTION
Some tests fail on my home machine. The failure reason must be identified before this can be merged.