### PR TITLE
Also exclude the benchmark and example program code from being published to crates.io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Update `criterion` dev-dependency to 0.7.0.
 - Update transitive dev-dependencies.
 - Skip installing the unneeded `jq` library in CI.
+- Don't package the benchmarks or examples to crates.io.
 
 ## 1.2.24
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.63.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/JSorngard/lambert_w"
 documentation = "https://docs.rs/lambert_w"
-exclude = ["tests/", ".github/", "CONTRIBUTING.md", "CHANGELOG.md"]
+exclude = ["tests/", ".github/", "CONTRIBUTING.md", "CHANGELOG.md", "benches", "examples"]
 
 [dependencies]
 num-complex = { version = "0.4.6", default-features = false }


### PR DESCRIPTION
Excluding those directories automatically removes the entries from the packaged Cargo.toml file. As a result it can still be compiled without errors!