### PR TITLE
Use the native referencing function in markdown for the reference section

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,21 +146,19 @@ of the standard library. Does nothing if the `std` feature is enabled.
 `std`: use the standard library to compute square roots and logarithms for a
 potential performance gain. When this feature is disabled the crate is `no_std` compatible.
 
-<div class = "rustdoc-hidden">
-
 ## License
 
-Licensed under either of <a href="LICENSE-APACHE.txt">Apache License, Version
-2.0</a> or <a href="LICENSE-MIT.txt">MIT license</a> at your option.
+Licensed under either of [Apache License, Version 2.0][]
+or [MIT license][] at your option.
 
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
 
-</div>
-
 [`approx`]: https://crates.io/crates/approx
 [`libm`]: https://crates.io/crates/libm
+[Apache License, Version 2.0]: LICENSE-APACHE.txt
+[MIT License]: LICENSE-MIT.txt
 
 ## References
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,8 @@
 // These links take precendence over the ones in the readme since they occur first.
 //! [`approx`]: https://docs.rs/approx/latest/approx/
 //! [`libm`]: https://docs.rs/libm/latest/libm/
+//! [Apache License, Version 2.0]: https://docs.rs/crate/lambert_w/latest/source/LICENSE-APACHE.txt
+//! [MIT license]: https://docs.rs/crate/lambert_w/latest/source/LICENSE-MIT.txt
 #![doc = include_str!("../README.md")]
 #![no_std]
 #![forbid(unsafe_code)]


### PR DESCRIPTION
Also link to the license files that are stored on docs.rs when on docs.rs.