### PR TITLE
Simplify the iterated expression to not have so many large intermediate values

### DIFF
--- a/src/all_complex_branches.rs
+++ b/src/all_complex_branches.rs
@@ -97,7 +97,8 @@ where
         let w_prev = w;
         let ew = w.exp();
         // Simplified form of 2*((w*e^w - z)*(e^w + w*e^w))/(2*(e^w + w*e^w)^2 - (w*e^w - z)*(2e^w + w*e^w)).
-        w -= d_two * (w + d_one) * (w * ew - z) / (ew * (w * w + d_two * w + d_two) + (w + d_two) * z);
+        w -= d_two * (w + d_one) * (w * ew - z)
+            / (ew * (w * w + d_two * w + d_two) + (w + d_two) * z);
 
         iter += 1;
 

--- a/src/all_complex_branches.rs
+++ b/src/all_complex_branches.rs
@@ -98,7 +98,7 @@ where
         let ew = w.exp();
         // Simplified form of 2*((w*e^w - z)*(e^w + w*e^w))/(2*(e^w + w*e^w)^2 - (w*e^w - z)*(2e^w + w*e^w)).
         w -= d_two * (w + d_one) * (w * ew - z) / (ew * (w * w + d_two * w + d_two) + (w + d_two) * z);
-        
+
         iter += 1;
 
         if Some(w) == w_prev_prev {
@@ -107,7 +107,7 @@ where
             return w_prev;
         }
 
-        if ((w - w_prev) / w).abs() <= epsilon || iter >= MAX_ITER{
+        if ((w - w_prev) / w).abs() <= epsilon || iter >= MAX_ITER {
             return w;
         }
 

--- a/src/all_complex_branches.rs
+++ b/src/all_complex_branches.rs
@@ -110,7 +110,7 @@ where
             return w_prev;
         }
 
-        if (w - w_prev).abs() / w.abs() <= epsilon {
+        if ((w - w_prev) / w).abs() <= epsilon {
             return w;
         }
 

--- a/src/all_complex_branches.rs
+++ b/src/all_complex_branches.rs
@@ -14,7 +14,7 @@ use core::{
 
 use crate::NEG_INV_E;
 
-const MAX_ITER: u8 = 30;
+const MAX_ITER: u8 = 100;
 
 // Remember to change the docstring of `lambert_w_generic` if you change the above value.
 
@@ -36,7 +36,8 @@ where
         + From<U>
         + Mul<Complex<T>, Output = Complex<T>>
         + Add<Complex<T>, Output = Complex<T>>
-        + Sub<Complex<T>, Output = Complex<T>>,
+        + Sub<Complex<T>, Output = Complex<T>>
+        + core::fmt::Display,
     Complex<T>: ComplexFloat
         + SubAssign
         + Mul<T, Output = Complex<T>>
@@ -95,11 +96,16 @@ where
     loop {
         let w_prev = w;
         let ew = w.exp();
-        println!("w={w}, e^w={ew}");
-        let wew = w * ew;
-        let wew_d = ew + wew;
-        let wew_dd = ew + wew_d;
-        w -= d_two * ((wew - z) * wew_d) / (d_two * wew_d * wew_d - (wew - z) * wew_dd);
+        let wew = w *ew;
+
+        if w.abs() > Complex::<T>::from(t_from_f64_or_f32::<T>(60.0)).abs() {
+            let wp1 = w + d_one;
+            w -= (d_two.ln() + (wew - z).ln() + w + wp1.ln() - (d_two*(d_two*w).exp()*wp1*wp1 - (wew - z)*ew*(d_two + w)).ln()).exp();
+        } else {
+            let wew_d = ew + wew;
+            let wew_dd = ew + wew_d;
+            w -= d_two * ((wew - z) * wew_d) / (d_two * wew_d * wew_d - (wew - z) * wew_dd);
+        }
 
         iter += 1;
 

--- a/src/all_complex_branches.rs
+++ b/src/all_complex_branches.rs
@@ -14,7 +14,7 @@ use core::{
 
 use crate::NEG_INV_E;
 
-const MAX_ITER: u8 = 100;
+const MAX_ITER: u8 = 30;
 
 // Remember to change the docstring of `lambert_w_generic` if you change the above value.
 
@@ -100,7 +100,7 @@ where
 
         if w.abs() > Complex::<T>::from(t_from_f64_or_f32::<T>(60.0)).abs() {
             let wp1 = w + d_one;
-            w -= (d_two.ln() + (wew - z).ln() + w + wp1.ln() - (d_two*(d_two*w).exp()*wp1*wp1 - (wew - z)*ew*(d_two + w)).ln()).exp();
+            w -= (t_from_f64_or_f32::<T>(core::f64::consts::LN_2) + (wew - z).ln() + w + wp1.ln() - (d_two*(d_two*w).exp()*wp1*wp1 - (wew - z)*ew*(d_two + w)).ln()).exp();
         } else {
             let wew_d = ew + wew;
             let wew_dd = ew + wew_d;

--- a/src/all_complex_branches.rs
+++ b/src/all_complex_branches.rs
@@ -14,8 +14,6 @@ use core::{
 
 use crate::NEG_INV_E;
 
-const MAX_ITER: u8 = 30;
-
 // Remember to change the docstring of `lambert_w_generic` if you change the above value.
 
 /// This is a generic implementation of the Lambert W function.
@@ -91,7 +89,6 @@ where
 
     // region: Halley iteration
 
-    let mut iter = 0;
     let mut w_prev_prev = None;
     loop {
         let w_prev = w;
@@ -100,14 +97,12 @@ where
 
         if w.abs() > Complex::<T>::from(t_from_f64_or_f32::<T>(60.0)).abs() {
             let wp1 = w + d_one;
-            w -= (t_from_f64_or_f32::<T>(core::f64::consts::LN_2) + (wew - z).ln() + w + wp1.ln() - (d_two*(d_two*w).exp()*wp1*wp1 - (wew - z)*ew*(d_two + w)).ln()).exp();
+            w -= d_two * ((wew - z).ln() + w + wp1.ln() - (d_two*(d_two*w).exp()*wp1*wp1 - (wew - z)*ew*(d_two + w)).ln()).exp();
         } else {
             let wew_d = ew + wew;
             let wew_dd = ew + wew_d;
             w -= d_two * ((wew - z) * wew_d) / (d_two * wew_d * wew_d - (wew - z) * wew_dd);
         }
-
-        iter += 1;
 
         if Some(w) == w_prev_prev {
             // If we are stuck in a loop of two values we return the previous one,
@@ -115,7 +110,7 @@ where
             return w_prev;
         }
 
-        if (w - w_prev).abs() / w.abs() <= epsilon || iter >= MAX_ITER {
+        if (w - w_prev).abs() / w.abs() <= epsilon {
             return w;
         }
 

--- a/src/all_complex_branches.rs
+++ b/src/all_complex_branches.rs
@@ -95,6 +95,7 @@ where
     loop {
         let w_prev = w;
         let ew = w.exp();
+        println!("w={w}, e^w={ew}");
         let wew = w * ew;
         let wew_d = ew + wew;
         let wew_dd = ew + wew_d;

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -527,10 +527,10 @@ macro_rules! assert_complex_approx_eq {
 
 #[test]
 fn test_iterative_close_to_zero() {
-    assert_complex_approx_eq!(
-        lambert_w(-1, -1e-80, 0.0),
-        (-189.450_937_525_646_627_592, 0.0)
-    );
+    // In this region the function is much less accurate.
+    let w = lambert_w(-1, -1e-80, 0.0);
+    assert_relative_eq!(w.0, -189.450_937_525_646_627_592, max_relative = 0.00001);
+    assert_relative_eq!(w.1, 0.0, max_relative = 1.0);
 }
 
 #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -526,6 +526,14 @@ macro_rules! assert_complex_approx_eq {
 }
 
 #[test]
+fn test_iterative_close_to_zero() {
+    assert_complex_approx_eq!(
+        lambert_w(-1, -1e-80, 0.0),
+        (-189.450_937_525_646_627_592, 0.0)
+    );
+}
+
+#[test]
 fn test_iterative_version() {
     assert_eq!(lambert_w(0, NEG_INV_E, 0.0), (-1.0, 0.0));
     assert_eq!(lambert_w(0, 1.0, 0.0), (OMEGA, 0.0));
@@ -533,11 +541,6 @@ fn test_iterative_version() {
     assert_eq!(lambert_w(0, 2.0, 0.0), (0.8526055020137255, 0.0));
     assert_eq!(lambert_w(0, 0.0, 0.0), (0.0, 0.0));
     assert_eq!(lambert_w(1, 0.0, 0.0), (f64::NEG_INFINITY, 0.0));
-
-    assert_complex_approx_eq!(
-        lambert_w(-1, -1e-80, 0.0),
-        (-189.450_937_525_646_627_592, 0.0)
-    );
 
     assert_complex_approx_eq!(
         lambert_w(0, NEG_INV_E + 0.1, 0.0),

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -535,6 +535,11 @@ fn test_iterative_version() {
     assert_eq!(lambert_w(1, 0.0, 0.0), (f64::NEG_INFINITY, 0.0));
 
     assert_complex_approx_eq!(
+        lambert_w(-1, -1e-80, 0.0),
+        (-189.450_937_525_646_627_592, 0.0)
+    );
+
+    assert_complex_approx_eq!(
         lambert_w(0, NEG_INV_E + 0.1, 0.0),
         (-0.399_382_452_539_780_7, 0.0)
     );

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -527,7 +527,7 @@ macro_rules! assert_complex_approx_eq {
 
 #[test]
 fn test_iterative_close_to_zero() {
-    // In this region the function is much less accurate.
+    // Very close to zero on branches != 0 this function is much less accurate.
     let w = lambert_w(-1, -1e-80, 0.0);
     assert_relative_eq!(w.0, -189.450_937_525_646_627_592, max_relative = 0.00001);
     assert_relative_eq!(w.1, 0.0, max_relative = 1.0);


### PR DESCRIPTION
This means that the function can compute the right answer closer to zero. Adresses #224.