### PR TITLE
Remove the note that we are using the coefficients from the Fortran code and not the paper from dw0c and dwm1c

### DIFF
--- a/src/dw0c.rs
+++ b/src/dw0c.rs
@@ -19,9 +19,8 @@ use crate::generic_math::{ln, rational_function, sqrt};
 #[inline(always)]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn dw0c(zc: f64) -> f64 {
-    // The critical arguments used in the if statements are related to the numbers in table 3 of the paper, column two, with 1/e added.
-    // The coefficients in the rational functions are related to the ones in the tables 10 through 14 in the paper.
-    // The actual numbers are taken from Fukushima's Fortran implementation.
+    // The critical arguments used in the if statements are the numbers in table 3 of the paper, column two, with 1/e added.
+    // The coefficients in the rational functions are the ones in tables 10 through 14 in the paper.
 
     if zc < 0.0 || zc.is_nan() {
         f64::NAN

--- a/src/dwm1c.rs
+++ b/src/dwm1c.rs
@@ -22,9 +22,8 @@ use crate::{
 #[inline(always)]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn dwm1c(z: f64, zc: f64) -> f64 {
-    // The critical arguments used in the if statements are related to the numbers in table 4 of the paper, column two, with 1/e added, as well as equation 20.
-    // The coefficients in the rational functions are related to the tables 15 through 18 in the paper.
-    // The actual numbers are taken from Fukushima's Fortran implementation.
+    // The critical arguments used in the if statements are the numbers in table 4 of the paper, column two, with 1/e added, as well as equation 20.
+    // The coefficients in the rational functions are from tables 15 through 18 in the paper.
 
     if zc < 0.0 {
         f64::NAN

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Johanna Sörngård
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-// The Fortran code by Fukushima for `dw0c`, `dwm1c`, `sw0`, and `swm1` can be found at
+// The Fortran code by Fukushima can be found at
 // <https://www.researchgate.net/publication/346096162_xlambwtxt_Fortran_90_test_program_package_of_sw0_swm1_dw0c_and_dwm1c_low-_and_high-precision_procedures_computing_primary_and_secondary_branch_of_Lambert_W_function_W_0z_or_W_-1z_by_piecewise_minimax_>.
 
 // These markdown ideas are taken from <https://linebender.org/blog/doc-include>.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,8 @@ mod unit_tests;
 // function in the crate can panic using the `no-panic` crate.
 // This is the source of all the `#[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]` attributes.
 
+// The Fortran code by Fukushima for `dw0c`, `dwm1c`, `sw0`, and `swm1` can be found at <https://www.researchgate.net/publication/346096162_xlambwtxt_Fortran_90_test_program_package_of_sw0_swm1_dw0c_and_dwm1c_low-_and_high-precision_procedures_computing_primary_and_secondary_branch_of_Lambert_W_function_W_0z_or_W_-1z_by_piecewise_minimax_>.
+
 /// The negative inverse of e (-1/e).
 ///
 /// This is the branch point of the Lambert W function.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Johanna Sörngård
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-// The Fortran code by Fukushima can be found at
+// The Fukushima's own implementation of the paper in Fortran can be found at
 // <https://www.researchgate.net/publication/346096162_xlambwtxt_Fortran_90_test_program_package_of_sw0_swm1_dw0c_and_dwm1c_low-_and_high-precision_procedures_computing_primary_and_secondary_branch_of_Lambert_W_function_W_0z_or_W_-1z_by_piecewise_minimax_>.
 
 // These markdown ideas are taken from <https://linebender.org/blog/doc-include>.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,6 @@ mod unit_tests;
 // function in the crate can panic using the `no-panic` crate.
 // This is the source of all the `#[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]` attributes.
 
-
 /// The negative inverse of e (-1/e).
 ///
 /// This is the branch point of the Lambert W function.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,9 @@
 // Copyright 2025 Johanna Sörngård
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+// The Fortran code by Fukushima for `dw0c`, `dwm1c`, `sw0`, and `swm1` can be found at
+// <https://www.researchgate.net/publication/346096162_xlambwtxt_Fortran_90_test_program_package_of_sw0_swm1_dw0c_and_dwm1c_low-_and_high-precision_procedures_computing_primary_and_secondary_branch_of_Lambert_W_function_W_0z_or_W_-1z_by_piecewise_minimax_>.
+
 // These markdown ideas are taken from <https://linebender.org/blog/doc-include>.
 //
 // This style is used in the readme itself to hide specific parts of it when rendered on docs.rs.
@@ -37,7 +40,6 @@ mod unit_tests;
 // function in the crate can panic using the `no-panic` crate.
 // This is the source of all the `#[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]` attributes.
 
-// The Fortran code by Fukushima for `dw0c`, `dwm1c`, `sw0`, and `swm1` can be found at <https://www.researchgate.net/publication/346096162_xlambwtxt_Fortran_90_test_program_package_of_sw0_swm1_dw0c_and_dwm1c_low-_and_high-precision_procedures_computing_primary_and_secondary_branch_of_Lambert_W_function_W_0z_or_W_-1z_by_piecewise_minimax_>.
 
 /// The negative inverse of e (-1/e).
 ///

--- a/src/sw0.rs
+++ b/src/sw0.rs
@@ -23,7 +23,8 @@ use crate::{
 pub fn sw0(z: f64) -> f64 {
     // The critical arguments used in the if statements are related to the numbers in table 3 of the paper, column one.
     // The coefficients in the rational functions are related from the tables 5 through 7 in the paper.
-    // The actual numbers are taken from Fukushima's Fortran implementation, which have higher precision.
+    // The actual numbers are taken from Fukushima's Fortran implementation, which have higher precision:
+    // <https://www.researchgate.net/publication/346096162_xlambwtxt_Fortran_90_test_program_package_of_sw0_swm1_dw0c_and_dwm1c_low-_and_high-precision_procedures_computing_primary_and_secondary_branch_of_Lambert_W_function_W_0z_or_W_-1z_by_piecewise_minimax_>.
 
     if z < NEG_INV_E || z.is_nan() {
         f64::NAN

--- a/src/sw0.rs
+++ b/src/sw0.rs
@@ -23,8 +23,7 @@ use crate::{
 pub fn sw0(z: f64) -> f64 {
     // The critical arguments used in the if statements are related to the numbers in table 3 of the paper, column one.
     // The coefficients in the rational functions are related from the tables 5 through 7 in the paper.
-    // The actual numbers are taken from Fukushima's Fortran implementation, which have higher precision:
-    // <https://www.researchgate.net/publication/346096162_xlambwtxt_Fortran_90_test_program_package_of_sw0_swm1_dw0c_and_dwm1c_low-_and_high-precision_procedures_computing_primary_and_secondary_branch_of_Lambert_W_function_W_0z_or_W_-1z_by_piecewise_minimax_>.
+    // The actual numbers are taken from Fukushima's Fortran implementation, which have higher precision.
 
     if z < NEG_INV_E || z.is_nan() {
         f64::NAN

--- a/src/sw0.rs
+++ b/src/sw0.rs
@@ -23,7 +23,7 @@ use crate::{
 pub fn sw0(z: f64) -> f64 {
     // The critical arguments used in the if statements are related to the numbers in table 3 of the paper, column one.
     // The coefficients in the rational functions are related from the tables 5 through 7 in the paper.
-    // The actual numbers are taken from Fukushima's Fortran implementation.
+    // The actual numbers are taken from Fukushima's Fortran implementation, which have higher precision.
 
     if z < NEG_INV_E || z.is_nan() {
         f64::NAN

--- a/src/swm1.rs
+++ b/src/swm1.rs
@@ -22,7 +22,8 @@ use crate::{
 pub fn swm1(z: f64) -> f64 {
     // The critical arguments used in the if statements are related to the numbers in table 4 of the paper, column one.
     // The coefficients in the rational functions are related to the tables 8 and 9 in the paper.
-    // The actual numbers are taken from Fukushima's Fortran implementation, which have higher precision.
+    // The actual numbers are taken from Fukushima's Fortran implementation, which have higher precision:
+    // <https://www.researchgate.net/publication/346096162_xlambwtxt_Fortran_90_test_program_package_of_sw0_swm1_dw0c_and_dwm1c_low-_and_high-precision_procedures_computing_primary_and_secondary_branch_of_Lambert_W_function_W_0z_or_W_-1z_by_piecewise_minimax_>.
 
     if z < NEG_INV_E {
         f64::NAN

--- a/src/swm1.rs
+++ b/src/swm1.rs
@@ -22,8 +22,7 @@ use crate::{
 pub fn swm1(z: f64) -> f64 {
     // The critical arguments used in the if statements are related to the numbers in table 4 of the paper, column one.
     // The coefficients in the rational functions are related to the tables 8 and 9 in the paper.
-    // The actual numbers are taken from Fukushima's Fortran implementation, which have higher precision:
-    // <https://www.researchgate.net/publication/346096162_xlambwtxt_Fortran_90_test_program_package_of_sw0_swm1_dw0c_and_dwm1c_low-_and_high-precision_procedures_computing_primary_and_secondary_branch_of_Lambert_W_function_W_0z_or_W_-1z_by_piecewise_minimax_>.
+    // The actual numbers are taken from Fukushima's Fortran implementation, which have higher precision.
 
     if z < NEG_INV_E {
         f64::NAN

--- a/src/swm1.rs
+++ b/src/swm1.rs
@@ -22,7 +22,7 @@ use crate::{
 pub fn swm1(z: f64) -> f64 {
     // The critical arguments used in the if statements are related to the numbers in table 4 of the paper, column one.
     // The coefficients in the rational functions are related to the tables 8 and 9 in the paper.
-    // The actual numbers are taken from Fukushima's Fortran implementation.
+    // The actual numbers are taken from Fukushima's Fortran implementation, which have higher precision.
 
     if z < NEG_INV_E {
         f64::NAN


### PR DESCRIPTION
The ones in the code and the paper are the same for this precision.

Add mention that the coefficients in sw0 and swm1 are taken from the source code and not the paper because the ones in the code have higher precision.