### PR TITLE
Enable linting for undocumented items

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Check with `libm`
       run: cargo check --no-default-features -F libm
     - name: Check with `std`
-      run: cargo check --no-default-features -F std 
+      run: cargo check --no-default-features -F std
     - name: Check with both
       run: cargo check --no-default-features -F libm,std
 


### PR DESCRIPTION
This adds a compilation warning if something in the crate is undocumented.

Since we error on warnings in the `clippy` CI job, a lack of docs will be caught in CI as well.