### PR TITLE
Document the benchmarks files, but allow `missing_docs` in them.

### DIFF
--- a/benches/fixed.rs
+++ b/benches/fixed.rs
@@ -1,6 +1,11 @@
 // Copyright 2025 Johanna Sörngård
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+//! Benchmarks for fixed arguments known at compile time.
+
+// The call to `criterion_group!` generates items that we can not document.
+#![allow(missing_docs)]
+
 use core::hint::black_box;
 use criterion::{criterion_group, criterion_main, Criterion};
 use lambert_w::{

--- a/benches/random.rs
+++ b/benches/random.rs
@@ -1,6 +1,11 @@
 // Copyright 2025 Johanna Sörngård
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+//! Benchmarks for random arguments generated at tunrim (from a fixed seed).
+
+// The call to `criterion_group!` generates items that we can not document.
+#![allow(missing_docs)]
+
 use core::hint::black_box;
 use core::ops::RangeBounds;
 use criterion::{


### PR DESCRIPTION
This is because the call to the `criterion_main!` macro generates items that we can not document, and we can not mark them with `allow(missing_docs)` either, so we have to allow it globally in the benchmarks