### PR TITLE
Specify `rand` version 0.9.2 instead of 0.9.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ num-traits = { version = "0.2.19", default-features = false }
 [dev-dependencies]
 approx = { version = "0.5.1", default-features = false }
 criterion = { version = "0.8.1", features = ["html_reports"] }
-rand = { version = "0.9.0", default-features = false, features = ["small_rng"] }
+rand = { version = "0.9.2", default-features = false, features = ["small_rng"] }
 plotters = { version = "0.3.0", default-features = false, features = ["bitmap_encoder", "bitmap_backend", "ttf"] }
 
 [features]


### PR DESCRIPTION
Since that is the version that ends up actually used.