### PR TITLE
Add 'panic="abort"' to the release-lto profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ always_include_features = ["libm"]
 inherits = "release"
 lto = "fat"
 codegen-units = 1
-# We do not want panic = "abort", as we want to be able to catch panics in the tests.
+panic="abort"
 
 [[bench]]
 name = "random"


### PR DESCRIPTION
This is now okay since we don't need the panics to remain for the `ensure_no_panics` CI job since it doesn't exist anymore.