### PR TITLE
Update `rand` to version 0.10.1 which fixes a soundness bug in version 0.10.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file contains the changes to the crate since version 0.1.1.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.3] - 2026-04-17
+
+- Update `rand` to version 0.10.1.
+
 ## [2.0.2] - 2026-04-16
 
 - Add explicit permissions to the CI jobs.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "lambert_w"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "approx",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ num-traits = { version = "0.2.19", default-features = false }
 [dev-dependencies]
 approx = { version = "0.5.1", default-features = false }
 criterion = { version = "0.8.2", features = ["html_reports"] }
-rand = { version = "0.10.0", default-features = false }
+rand = { version = "0.10.1", default-features = false }
 kuva = "0.1.6"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambert_w"
-version = "2.0.2"
+version = "2.0.3"
 edition = "2021"
 authors = ["Johanna Sörngård <jsorngard@gmail.com>"]
 categories = ["mathematics", "no-std", "no-std::no-alloc"]


### PR DESCRIPTION
Version 0.10.0 of  `rand` is unsound (https://github.com/rust-random/rand/pull/1763).