### PR TITLE
Specify the type of 32-bit float literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Update transitive dev-dependencies.
 - Update `codecov` action to version 7.
 - Documentation improvements.
+- Improvements in unit tests that fixes a future incompatibility.
 
 ## [2.0.3] - 2026-04-17
 

--- a/src/unit_tests.rs
+++ b/src/unit_tests.rs
@@ -13,16 +13,24 @@ use num_complex::{c32, c64};
 
 #[test]
 fn test_are_nearly_equal() {
-    assert!(are_nearly_equal(c32(0.0, 0.0), c32(0.0, 0.0), f32::EPSILON));
-    assert!(!are_nearly_equal(
-        c32(0.0, f32::NAN),
-        c32(0.0, 0.0),
+    assert!(are_nearly_equal(
+        c32(0.0_f32, 0.0_f32),
+        c32(0.0_f32, 0.0_f32),
         f32::EPSILON
     ));
-    assert!(are_nearly_equal(c32(10.0, 0.0), c32(10.000001, 0.0), 0.01));
     assert!(!are_nearly_equal(
-        c32(f32::MIN_POSITIVE / 3.0, 0.0),
-        c32(f32::MIN_POSITIVE / 6.0, 0.0),
+        c32(0.0_f32, f32::NAN),
+        c32(0.0_f32, 0.0_f32),
+        f32::EPSILON
+    ));
+    assert!(are_nearly_equal(
+        c32(10.0_f32, 0.0_f32),
+        c32(10.000001_f32, 0.0_f32),
+        0.01_f32
+    ));
+    assert!(!are_nearly_equal(
+        c32(f32::MIN_POSITIVE / 3.0_f32, 0.0_f32),
+        c32(f32::MIN_POSITIVE / 6.0_f32, 0.0_f32),
         0.1,
     ));
 


### PR DESCRIPTION
the `c32` function that takes 32-bit floats was before this PR invoked in ways like `c32(0.0, 0.0)`. Those literals are actually 64-bit constants by Rust rules. This will result in a compiler error in the future, so this PR explicitly types them as `_f32`.